### PR TITLE
Fix `Building an Example` example command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are compiling the crate on its own for development or running examples,
 specify your microcontroller on the command line. For example:
 
 ```
-cargo build --example blinky
+cargo build --example blinky --features stm32g07x
 ```
 
 ### Using as a Dependency


### PR DESCRIPTION
Actually add the microcontroller to the command as is stated in the text above.