### PR TITLE
Use `Infallible` as error type for gpio api

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -76,6 +76,7 @@ macro_rules! gpio {
     ]) => {
         /// GPIO
         pub mod $gpiox {
+            use core::convert::Infallible;
             use core::marker::PhantomData;
             use hal::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
             use crate::stm32::{EXTI, $GPIOX};
@@ -110,15 +111,15 @@ macro_rules! gpio {
             }
 
             impl<MODE> OutputPin for $PXx<Output<MODE>> {
-                type Error = ();
+                type Error = Infallible;
 
-                fn set_high(&mut self) -> Result<(), ()> {
+                fn set_high(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) };
                     Ok(())
                 }
 
-                fn set_low(&mut self) -> Result<(), ()> {
+                fn set_low(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (self.i + 16))) };
                     Ok(())
@@ -126,12 +127,12 @@ macro_rules! gpio {
             }
 
             impl<MODE> StatefulOutputPin for $PXx<Output<MODE>> {
-                fn is_set_high(&self) -> Result<bool, ()> {
+                fn is_set_high(&self) -> Result<bool, Self::Error> {
                     let is_set_high = !self.is_set_low()?;
                     Ok(is_set_high)
                 }
 
-                fn is_set_low(&self) -> Result<bool, ()> {
+                fn is_set_low(&self) -> Result<bool, Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let is_set_low = unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 };
                     Ok(is_set_low)
@@ -142,14 +143,14 @@ macro_rules! gpio {
             }
 
             impl<MODE> InputPin for $PXx<Output<MODE>> {
-                type Error = ();
+                type Error = Infallible;
 
-                fn is_high(&self) -> Result<bool, ()> {
+                fn is_high(&self) -> Result<bool, Self::Error> {
                     let is_high = !self.is_low()?;
                     Ok(is_high)
                 }
 
-                fn is_low(&self) -> Result<bool, ()>  {
+                fn is_low(&self) -> Result<bool, Self::Error>  {
                     // NOTE(unsafe) atomic read with no side effects
                     let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 };
                     Ok(is_low)
@@ -157,14 +158,14 @@ macro_rules! gpio {
             }
 
             impl<MODE> InputPin for $PXx<Input<MODE>> {
-                type Error = ();
+                type Error = Infallible;
 
-                fn is_high(&self) -> Result<bool, ()> {
+                fn is_high(&self) -> Result<bool, Self::Error> {
                     let is_high = !self.is_low()?;
                     Ok(is_high)
                 }
 
-                fn is_low(&self) -> Result<bool, ()> {
+                fn is_low(&self) -> Result<bool, Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 };
                     Ok(is_low)
@@ -382,15 +383,15 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
-                    type Error = ();
+                    type Error = Infallible;
 
-                    fn set_high(&mut self) -> Result<(), ()> {
+                    fn set_high(&mut self) -> Result<(), Self::Error> {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) };
                         Ok(())
                     }
 
-                    fn set_low(&mut self) -> Result<(), ()>{
+                    fn set_low(&mut self) -> Result<(), Self::Error>{
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << ($i + 16))) };
                         Ok(())
@@ -398,12 +399,12 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
-                    fn is_set_high(&self) -> Result<bool, ()> {
+                    fn is_set_high(&self) -> Result<bool, Self::Error> {
                         let is_set_high = !self.is_set_low()?;
                         Ok(is_set_high)
                     }
 
-                    fn is_set_low(&self) -> Result<bool, ()> {
+                    fn is_set_low(&self) -> Result<bool, Self::Error> {
                         // NOTE(unsafe) atomic read with no side effects
                         let is_set_low = unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 };
                         Ok(is_set_low)
@@ -414,14 +415,14 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> InputPin for $PXi<Output<MODE>> {
-                    type Error = ();
+                    type Error = Infallible;
 
-                    fn is_high(&self) -> Result<bool, ()> {
+                    fn is_high(&self) -> Result<bool, Self::Error> {
                         let is_high = !self.is_low()?;
                         Ok(is_high)
                     }
 
-                    fn is_low(&self) -> Result<bool, ()>  {
+                    fn is_low(&self) -> Result<bool, Self::Error>  {
                         // NOTE(unsafe) atomic read with no side effects
                         let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 };
                         Ok(is_low)
@@ -439,14 +440,14 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> InputPin for $PXi<Input<MODE>> {
-                    type Error = ();
+                    type Error = Infallible;
 
-                    fn is_high(&self) -> Result<bool, ()> {
+                    fn is_high(&self) -> Result<bool, Self::Error> {
                         let is_high = !self.is_low()?;
                         Ok(is_high)
                     }
 
-                    fn is_low(&self) -> Result<bool, ()> {
+                    fn is_low(&self) -> Result<bool, Self::Error> {
                         // NOTE(unsafe) atomic read with no side effects
                         let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 };
                         Ok(is_low)


### PR DESCRIPTION
Since the stm32g0 gpio operations are not fallible.

This patch brings this crate more in line with the other stm32-hal crates. 