### PR TITLE
Remove default = ["rt", "stm32g07x"] form Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ smart-leds = {git = "https://github.com/smart-leds-rs/smart-leds"}
 ws2812-spi = {git = "https://github.com/smart-leds-rs/ws2812-spi-rs"}
 
 [features]
-default = ["rt", "stm32g07x"]
 rt = ["stm32g0/rt"]
 stm32g07x = ["stm32g0/stm32g07x"]
 stm32g030 = ["stm32g0/stm32g030"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 repository = "https://github.com/stm32-rs/stm32g0xx-hal"
 version = "0.0.7"
 
+[package.metadata.docs.rs]
+features = ["stm32g07x", "rt"]
+default-target = "thumbv6m-none-eabi"
+
 [dependencies]
 cortex-m = "0.6.1"
 nb = "0.1.1"


### PR DESCRIPTION
`default = ["rt", "stm32g07x"]` breaks build for other targets: https://github.com/stm32-rs/stm32g0xx-hal/issues/6.

Those creates are also not using `default`:
https://github.com/stm32-rs/stm32l4xx-hal/blob/master/Cargo.toml#L54
https://github.com/stm32-rs/stm32f4xx-hal/blob/master/Cargo.toml#L63

