### PR TITLE
DAC improvements

### DIFF
--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -19,13 +19,12 @@ fn main() -> ! {
     let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     let mut rcc = dp.RCC.constrain();
-    let mut delay = cp.SYST.delay(&rcc);
+    let mut delay = cp.SYST.delay(&mut rcc);
 
     let gpioa = dp.GPIOA.split(&mut rcc);
-    let mut dac = dp.DAC.constrain(gpioa.pa4, &mut rcc);
+    let dac = dp.DAC.constrain(gpioa.pa4, &mut rcc);
 
-    dac.calibrate(&mut delay);
-    dac.enable();
+    let mut dac = dac.calibrate_buffer(&mut delay).enable();
 
     let mut dir = Direction::Upcounting;
     let mut val = 0;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,8 +9,6 @@ pub use crate::analog::adc::AdcExt as _;
 pub use crate::analog::dac::DacExt as _;
 #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
 pub use crate::analog::dac::DacOut as _;
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
-pub use crate::analog::dac::DacPin as _;
 // #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
 // pub use crate::comparator::ComparatorExt as _;
 pub use crate::crc::CrcExt as _;


### PR DESCRIPTION
* Add support for unbuffered outputs
* Clarify that calibration refers to the output buffer
* Add typestates, although DacOut trait remains implemented for all typestates
* Add disable method
* Add some documentation

See also some discussion for the same peripheral in the H7 HAL https://github.com/stm32-rs/stm32h7xx-hal/pull/69