### PR TITLE
Changed chunking of u8 data for digests

### DIFF
--- a/examples/crc.rs
+++ b/examples/crc.rs
@@ -19,13 +19,16 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().expect("cannot take peripherals");
     let mut rcc = dp.RCC.constrain();
 
-    let mut crc = dp.CRC.constrain(&mut rcc);
-    crc.reverse_input(InputReverse::Word);
-    crc.reverse_output(true);
+    let crc = dp.CRC.constrain(&mut rcc);
+    let mut crc = crc.input_bit_reversal(Some(BitReversal::ByWord))
+        .output_bit_reversal(true)
+        .freeze();
 
     loop {
         crc.reset();
-        let hash_sum = crc.digest("123456789");
+        crc.feed(b"123456789");
+
+        let hash_sum = crc.result();
         hprintln!(
             "crc32: 0x{:x}, crc32b: 0x{:x}",
             hash_sum,
@@ -34,7 +37,8 @@ fn main() -> ! {
         .unwrap();
 
         crc.reset();
-        let hash_sum = crc.digest("The quick brown fox jumps over the lazy dog");
+        crc.feed(b"The quick brown fox jumps over the lazy dog");
+        let hash_sum = crc.result();
         hprintln!(
             "crc32: 0x{:x}, crc32b: 0x{:x}",
             hash_sum,

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,135 +1,221 @@
-//! # Cyclic redundancy check calculation unit
+//! CRC calculation unit
+//!
+//! This unit is modeled after the [corresponding unit in the stm32l4xx-hal](https://github.com/stm32-rs/stm32l4xx-hal/blob/master/src/crc.rs).
+//! 
+//! Usage example:
+//! ```
+//! let crc = dp.RCC.constrain();
+//!
+//! // Lets use the CRC-16-CCITT polynomial
+//! let mut crc = crc.polynomial(crc::Polynomial::L16(0x1021)).freeze();
+//!
+//! let data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+//! crc.feed(&data);
+//!
+//! let result = crc.result();
+//! assert!(result == 0x78cb);
+//! ```
+
+#![deny(missing_docs)]
+
 use crate::rcc::Rcc;
 use crate::stm32::CRC;
+use core::hash::Hasher;
+use core::ptr;
 
-pub enum InputReverse {
-    None = 0b00,
-    Byte = 0b01,
-    HalfWord = 0b10,
-    Word = 0b11,
-}
-
-pub enum PolySize {
-    CRC32 = 0b00,
-    CRC16 = 0b01,
-    CRC8 = 0b10,
-    CRC7 = 0b11,
-}
-
-pub struct Crc {
-    rb: CRC,
-}
-
-impl Crc {
-    pub fn polynomial(&mut self, size: PolySize, poly: u32) {
-        self.reset();
-        self.rb.pol.modify(|_, w| unsafe { w.bits(poly) });
-        self.rb
-            .cr
-            .modify(|_, w| unsafe { w.polysize().bits(size as u8) });
-    }
-
-    pub fn seed(&mut self, value: u32) {
-        self.rb.init.modify(|_, w| unsafe { w.bits(value) });
-    }
-
-    pub fn reverse_output(&mut self, rev_out: bool) {
-        self.rb.cr.modify(|_, w| w.rev_out().bit(rev_out));
-    }
-
-    pub fn reverse_input(&mut self, rev_in: InputReverse) {
-        self.rb
-            .cr
-            .modify(|_, w| unsafe { w.rev_in().bits(rev_in as u8) });
-    }
-
-    pub fn reset(&mut self) {
-        self.rb.cr.modify(|_, w| w.reset().set_bit());
-    }
-
-    pub fn release(self) -> CRC {
-        self.rb
-    }
-}
-
-pub trait Digest<W> {
-    fn digest(&mut self, data: W) -> u32;
-}
-
-impl Digest<u32> for Crc {
-    fn digest(&mut self, data: u32) -> u32 {
-        self.rb.dr.write(|w| unsafe { w.dr().bits(data) });
-        self.rb.dr.read().bits()
-    }
-}
-
-impl Digest<&[u32]> for Crc {
-    fn digest(&mut self, data: &[u32]) -> u32 {
-        data.iter().map(|v| self.digest(*v)).last();
-        self.rb.dr.read().bits()
-    }
-}
-
-impl Digest<&[u16]> for Crc {
-    fn digest(&mut self, data: &[u16]) -> u32 {
-        data.iter()
-            .map(|v| unsafe {
-                core::ptr::write_volatile(&self.rb.dr as *const _ as *mut u16, *v);
-            })
-            .last();
-        self.rb.dr.read().bits()
-    }
-}
-
-impl Digest<&[u8]> for Crc {
-    fn digest(&mut self, data: &[u8]) -> u32 {
-        let mut iter32 = data.chunks_exact(4);
-        loop {
-            match iter32.next() {
-                Some(x) => {
-                    self.digest(u32::from_be_bytes([x[0], x[1], x[2], x[3]]));
-                },
-                None => break,
-            }
-        }
-        let mut iter16 = iter32.remainder().chunks_exact(2);
-        loop {
-            match iter16.next() {
-                Some(x) => {
-                    self.digest(&[u16::from_be_bytes([x[0], x[1]])][..]);
-                },
-                None => break,
-            }
-        }
-        let mut iter8 = iter16.remainder().iter();
-        loop {
-            match iter8.next() {
-                Some(x) => {
-                    unsafe { core::ptr::write_volatile(&self.rb.dr as *const _ as *mut u8, *x); }
-                },
-                None => break,
-            }
-        }
-
-        self.rb.dr.read().bits()
-    }
-}
-
-impl Digest<&str> for Crc {
-    fn digest(&mut self, s: &str) -> u32 {
-        self.digest(&s.as_bytes()[..])
-    }
-}
-
+/// Extension trait to constrain the CRC peripheral.
 pub trait CrcExt {
-    fn constrain(self, rcc: &mut Rcc) -> Crc;
+    /// Constrains the CRC peripheral to play nicely with the other abstractions
+    fn constrain(self, rcc: &mut Rcc) -> Config;
 }
 
 impl CrcExt for CRC {
-    fn constrain(self, rcc: &mut Rcc) -> Crc {
+    fn constrain(self, rcc: &mut Rcc) -> Config {
+        // Enable power to CRC unit
         rcc.rb.ahbenr.modify(|_, w| w.crcen().set_bit());
+        // Reset CRC unit
         rcc.rb.ahbrstr.modify(|_, w| w.crcrst().set_bit());
         rcc.rb.ahbrstr.modify(|_, w| w.crcrst().clear_bit());
-        Crc { rb: self }
+
+        // Default values
+        Config {
+            initial_value: 0xffff_ffff,
+            polynomial: Polynomial::L32(0x04c1_1db7),
+            input_bit_reversal: None,
+            output_bit_reversal: false,
+        }
+    }
+}
+
+/// Polynomial settings.
+pub enum Polynomial {
+    /// 7-bit polynomial, only the lowest 7 bits are valid
+    L7(u8),
+    /// 8-bit polynomial
+    L8(u8),
+    /// 16-bit polynomial
+    L16(u16),
+    /// 32-bit polynomial
+    L32(u32),
+}
+
+/// Bit reversal settings.
+pub enum BitReversal {
+    /// Reverse bits by byte
+    ByByte,
+    /// Reverse bits by half-word
+    ByHalfWord,
+    /// Reverse bits by word
+    ByWord,
+}
+
+/// CRC configuration structure, uses builder pattern.
+pub struct Config {
+    initial_value: u32,
+    polynomial: Polynomial,
+    input_bit_reversal: Option<BitReversal>,
+    output_bit_reversal: bool,
+}
+
+impl Config {
+    /// Sets the initial value of the CRC.
+    pub fn initial_value(mut self, init: u32) -> Self {
+        self.initial_value = init;
+
+        self
+    }
+
+    /// Sets the polynomial of the CRC.
+    pub fn polynomial(mut self, polynomial: Polynomial) -> Self {
+        self.polynomial = polynomial;
+
+        self
+    }
+
+    /// Enables bit reversal of the inputs.
+    pub fn input_bit_reversal(mut self, rev: Option<BitReversal>) -> Self {
+        self.input_bit_reversal = rev;
+
+        self
+    }
+
+    /// Enables bit reversal of the outputs.
+    pub fn output_bit_reversal(mut self, rev: bool) -> Self {
+        self.output_bit_reversal = rev;
+
+        self
+    }
+
+    /// Freezes the peripheral, making the configuration take effect.
+    pub fn freeze(self) -> Crc {
+        let crc = unsafe { &(*CRC::ptr()) };
+
+        let (poly, poly_bits, init) = match self.polynomial {
+            Polynomial::L7(val) => ((val & 0x7f) as u32, 0b11, self.initial_value & 0x7f),
+            Polynomial::L8(val) => (val as u32, 0b10, self.initial_value & 0xff),
+            Polynomial::L16(val) => (val as u32, 0b01, self.initial_value & 0xffff),
+            Polynomial::L32(val) => (val, 0b00, self.initial_value),
+        };
+
+        let in_rev_bits = match self.input_bit_reversal {
+            None => 0b00,
+            Some(BitReversal::ByByte) => 0b01,
+            Some(BitReversal::ByHalfWord) => 0b10,
+            Some(BitReversal::ByWord) => 0b11,
+        };
+
+        crc.init.write(|w| unsafe { w.crc_init().bits(init) });
+        crc.pol.write(|w| unsafe { w.bits(poly) });
+        crc.cr.write(|w| {
+            unsafe {
+                w.rev_in()
+                    .bits(in_rev_bits)
+                    .polysize()
+                    .bits(poly_bits)
+                    .reset()
+                    .set_bit();
+            }
+
+            if self.output_bit_reversal {
+                w.rev_out().set_bit()
+            } else {
+                w.rev_out().clear_bit()
+            }
+        });
+
+        Crc {}
+    }
+}
+
+/// Constrained CRC peripheral.
+pub struct Crc {}
+
+impl Crc {
+    /// This will reset the CRC to its initial condition.
+    #[inline]
+    pub fn reset(&mut self) {
+        let crc = unsafe { &(*CRC::ptr()) };
+
+        crc.cr.modify(|_, w| w.reset().set_bit());
+    }
+
+    /// This will reset the CRC to its initial condition, however with a specific initial value.
+    /// This is very useful if many task are sharing the CRC peripheral, as one can read out the
+    /// intermediate result, store it until the next time a task runs, and initialize with the
+    /// intermediate result to continue where the task left off.
+    #[inline]
+    pub fn reset_with_inital_value(&mut self, initial_value: u32) {
+        let crc = unsafe { &(*CRC::ptr()) };
+
+        crc.init
+            .write(|w| unsafe { w.crc_init().bits(initial_value) });
+        crc.cr.modify(|_, w| w.reset().set_bit());
+    }
+
+    /// Feed the CRC with data
+    #[inline]
+    pub fn feed(&mut self, data: &[u8]) {
+        let crc = unsafe { &(*CRC::ptr()) };
+        for byte in data {
+            unsafe {
+                // Workaround with svd2rust, it does not generate the byte interface to the DR
+                // register
+                ptr::write_volatile(&crc.dr as *const _ as *mut u8, *byte);
+            }
+        }
+    }
+
+    /// Get the result of the CRC, depending on the polynomial chosen only a certain amount of the
+    /// bits are the result. This will reset the CRC peripheral after use.
+    #[inline]
+    pub fn result(&mut self) -> u32 {
+        let ret = self.peek_result();
+
+        self.reset();
+
+        ret
+    }
+
+    /// Get a peed at the result of the CRC, depending on the polynomial chosen only a certain
+    /// amount of the bits are the result.
+    #[inline]
+    pub fn peek_result(&self) -> u32 {
+        let crc = unsafe { &(*CRC::ptr()) };
+
+        crc.dr.read().bits()
+    }
+}
+
+impl Hasher for Crc {
+    #[inline]
+    fn finish(&self) -> u64 {
+        // `peek_result` as `core::hash::Hasher` required that the `finish` method does not reset
+        // the hasher.
+        self.peek_result() as u64
+    }
+
+    #[inline]
+    fn write(&mut self, data: &[u8]) {
+        self.feed(data);
     }
 }


### PR DESCRIPTION
I changed the chunking of the u8 data for digests to make the results consistent with known examples and the digest method for u32 data.

Testing for the possibility to combine two u8 into one u16 might not be worth it, as it saves max one digest call.

The solution might not be very idiomatic for Rust as I am new to the language. Looking forward to your feedback.

Fixes #16 