### PR TITLE
Replace "stm32g07x" feature guards

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,15 @@
   "rust.all_features": false,
   "rust.features": [
     "rt",
-    "stm32g07x"
+    "stm32g081"
+  ],
+  "rust-analyzer.checkOnSave.allTargets": false,
+  "rust-analyzer.checkOnSave.extraArgs": [
+      "--target",
+      "thumbv6m-none-eabi"
+  ],
+  "rust-analyzer.cargo.features": [
+    "rt",
+    "stm32g081"
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,19 @@ ws2812-spi = {git = "https://github.com/smart-leds-rs/ws2812-spi-rs"}
 
 [features]
 rt = ["stm32g0/rt"]
-stm32g07x = ["stm32g0/stm32g07x"]
-stm32g030 = ["stm32g0/stm32g030"]
-stm32g031 = ["stm32g0/stm32g031"]
-stm32g041 = ["stm32g0/stm32g041"]
-stm32g081 = ["stm32g0/stm32g081"]
+
+stm32g030 = ["stm32g0/stm32g030", "stm32g0x0"]
+stm32g070 = ["stm32g0/stm32g07x", "stm32g0x0"]
+stm32g031 = ["stm32g0/stm32g031", "stm32g0x1"]
+stm32g041 = ["stm32g0/stm32g041", "stm32g0x1"]
+stm32g071 = ["stm32g0/stm32g07x", "stm32g0x1"]
+stm32g081 = ["stm32g0/stm32g081", "stm32g0x1"]
+
+stm32g0x0 = []
+stm32g0x1 = []
+
+# deprecated, map to "stm32g071" for now
+stm32g07x = ["stm32g0/stm32g07x", "stm32g071"]
 
 [profile.dev]
 incremental = false

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ specified with a feature, for example `stm32g070`.
 
 ### Building an Example
 
-If you are compiling the crate on its own for development or running examples, 
+If you are compiling the crate on its own for development or running examples,
 specify your microcontroller on the command line. For example:
 
 ```
-cargo build --example blinky --features stm32g07x
+cargo build --example blinky --features stm32g071
 ```
 
 ### Using as a Dependency
 
-When using this crate as a dependency in your project, the microcontroller can 
+When using this crate as a dependency in your project, the microcontroller can
 be specified as part of the `Cargo.toml` definition.
 
 ```

--- a/src/analog/mod.rs
+++ b/src/analog/mod.rs
@@ -1,3 +1,3 @@
 pub mod adc;
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 pub mod dac;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -175,14 +175,18 @@ macro_rules! delays {
 
 delays! {
     TIM1: (tim1, tim1en, tim1rst, apbenr2, apbrstr2),
-    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1),
     TIM3: (tim3, tim3en, tim3rst, apbenr1, apbrstr1),
     TIM14: (tim14, tim14en, tim14rst, apbenr2, apbrstr2),
     TIM16: (tim16, tim16en, tim16rst, apbenr2, apbrstr2),
     TIM17: (tim17, tim17en, tim17rst, apbenr2, apbrstr2),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(feature = "stm32g0x1")]
+delays! {
+    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1),
+}
+
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 delays! {
     TIM6: (tim6, tim6en, tim6rst, apbenr1, apbrstr1),
     TIM7: (tim7, tim7en, tim7rst, apbenr1, apbrstr1),

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -103,12 +103,11 @@ impl ExtiExt for EXTI {
     }
 
     fn wakeup(&self, ev: Event) {
-        #[cfg(any(feature = "stm32g030", feature = "stm32g031", feature = "stm32041"))]
+        #[cfg(any(feature = "stm32g030",  feature = "stm32070", feature = "stm32g031", feature = "stm32041"))]
         self.imr1
             .modify(|r, w| unsafe { w.bits(r.bits() | 1 << ev as u8) });
 
-        // TODO how to replace "stm32g07x"
-        #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+        #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
         match ev as u8 {
             line if line < 32 => self
                 .imr1()
@@ -122,7 +121,7 @@ impl ExtiExt for EXTI {
     fn unlisten(&self, ev: Event) {
         self.unpend(ev);
 
-        #[cfg(any(feature = "stm32g030", feature = "stm32g031", feature = "stm32041"))]
+        #[cfg(any(feature = "stm32g030",feature = "stm32g070", feature = "stm32g031", feature = "stm32041"))]
         {
             let line = ev as u8;
             let mask = !(1 << line);
@@ -133,8 +132,7 @@ impl ExtiExt for EXTI {
             }
         }
 
-        // TODO how to replace "stm32g07x"
-        #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+        #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
         match ev as u8 {
             line if line < 32 => {
                 let mask = !(1 << line);

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -22,24 +22,24 @@ pub enum Event {
     GPIO14 = 14,
     GPIO15 = 15,
     PVD = 16,
-    #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+    #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
     COMP1 = 17,
-    #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+    #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
     COMP2 = 18,
     RTC = 19,
     TAMP = 21,
     I2C1 = 23,
     USART1 = 25,
     USART2 = 26,
-    #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+    #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
     CEC = 27,
     LPUART1 = 28,
     LPTIM1 = 29,
     LPTIM2 = 30,
     LSE_CSS = 31,
-    #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+    #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
     UCPD1 = 32,
-    #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+    #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
     UCPD2 = 33,
 }
 
@@ -67,10 +67,12 @@ impl Event {
     }
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 const TRIGGER_MAX: u8 = 18;
-#[cfg(any(feature = "stm32g030", feature = "stm32g031", feature = "stm32041"))]
+#[cfg(any(feature = "stm32g031", feature = "stm32041"))]
 const TRIGGER_MAX: u8 = 16;
+#[cfg(any(feature = "stm32g030", feature = "stm32g070"))]
+const TRIGGER_MAX: u8 = 15;
 
 pub trait ExtiExt {
     fn wakeup(&self, ev: Event);
@@ -105,6 +107,7 @@ impl ExtiExt for EXTI {
         self.imr1
             .modify(|r, w| unsafe { w.bits(r.bits() | 1 << ev as u8) });
 
+        // TODO how to replace "stm32g07x"
         #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
         match ev as u8 {
             line if line < 32 => self
@@ -130,6 +133,7 @@ impl ExtiExt for EXTI {
             }
         }
 
+        // TODO how to replace "stm32g07x"
         #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
         match ev as u8 {
             line if line < 32 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,15 @@
 #![allow(non_camel_case_types)]
 
 #[cfg(not(any(
-    feature = "stm32g07x",
+    feature = "stm32g070",
+    feature = "stm32g071",
     feature = "stm32g030",
     feature = "stm32g031",
     feature = "stm32g041",
     feature = "stm32g081"
 )))]
 compile_error!(
-    "This crate requires one of the following features enabled: stm32g07x, stm32g030, stm32g031, stm32g041, stm32g081"
+    "This crate requires one of the following features enabled: stm32g030, stm32g070, stm32g031, stm32g041, stm32g071, stm32g081"
 );
 
 extern crate bare_metal;
@@ -22,17 +23,20 @@ pub extern crate stm32g0;
 
 pub use nb::block;
 
-#[cfg(feature = "stm32g07x")]
-pub use stm32g0::stm32g07x as stm32;
-
 #[cfg(feature = "stm32g030")]
 pub use stm32g0::stm32g030 as stm32;
+
+#[cfg(feature = "stm32g070")]
+pub use stm32g0::stm32g07x as stm32;  // TODO should be stm32g070, to be fixed in pac
 
 #[cfg(feature = "stm32g031")]
 pub use stm32g0::stm32g031 as stm32;
 
 #[cfg(feature = "stm32g041")]
 pub use stm32g0::stm32g041 as stm32;
+
+#[cfg(feature = "stm32g071")]
+pub use stm32g0::stm32g07x as stm32; // TODO should be stm32g071, to be fixed in pac
 
 #[cfg(feature = "stm32g081")]
 pub use stm32g0::stm32g081 as stm32;
@@ -41,7 +45,7 @@ pub use stm32g0::stm32g081 as stm32;
 pub use crate::stm32::interrupt;
 
 pub mod analog;
-// #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+// #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 // pub mod comparator;
 pub mod crc;
 pub mod delay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use nb::block;
 pub use stm32g0::stm32g030 as stm32;
 
 #[cfg(feature = "stm32g070")]
-pub use stm32g0::stm32g07x as stm32;  // TODO should be stm32g070, to be fixed in pac
+pub use stm32g0::stm32g07x as stm32;  // TODO will be stm32g070, to be fixed in next pac release
 
 #[cfg(feature = "stm32g031")]
 pub use stm32g0::stm32g031 as stm32;
@@ -36,7 +36,7 @@ pub use stm32g0::stm32g031 as stm32;
 pub use stm32g0::stm32g041 as stm32;
 
 #[cfg(feature = "stm32g071")]
-pub use stm32g0::stm32g07x as stm32; // TODO should be stm32g071, to be fixed in pac
+pub use stm32g0::stm32g07x as stm32; // TODO will be stm32g071, to be fixed in next pac release
 
 #[cfg(feature = "stm32g081")]
 pub use stm32g0::stm32g081 as stm32;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,11 +5,11 @@ pub use hal::watchdog::Watchdog as _;
 pub use hal::watchdog::WatchdogEnable as _;
 
 pub use crate::analog::adc::AdcExt as _;
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 pub use crate::analog::dac::DacExt as _;
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 pub use crate::analog::dac::DacOut as _;
-// #[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+// #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 // pub use crate::comparator::ComparatorExt as _;
 pub use crate::crc::CrcExt as _;
 pub use crate::delay::DelayExt as _;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -499,20 +499,6 @@ macro_rules! uart {
 }
 
 uart!(
-    LPUART, lpuart, apbenr1, lpuart1en, 256,
-    tx: [
-        (PA2<DefaultMode>, AltFunction::AF6),
-        (PB11<DefaultMode>, AltFunction::AF1),
-        (PC1<DefaultMode>, AltFunction::AF1),
-    ],
-    rx: [
-        (PA3<DefaultMode>, AltFunction::AF6),
-        (PB10<DefaultMode>, AltFunction::AF1),
-        (PC0<DefaultMode>, AltFunction::AF1),
-    ],
-);
-
-uart!(
     USART1, usart1, apbenr2, usart1en, 1,
     tx: [
         (PA9<DefaultMode>, AltFunction::AF1),
@@ -540,7 +526,7 @@ uart!(
     ],
 );
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070",feature = "stm32g071", feature = "stm32g081"))]
 uart!(
     USART3, usart3, apbenr1, usart3en, 1,
     tx: [
@@ -562,7 +548,7 @@ uart!(
     ],
 );
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070",feature = "stm32g071", feature = "stm32g081"))]
 uart!(
     USART4, usart4, apbenr1, usart4en, 1,
     tx: [
@@ -572,5 +558,20 @@ uart!(
     rx: [
         (PC11<DefaultMode>, AltFunction::AF1),
         (PA1<DefaultMode>, AltFunction::AF4),
+    ],
+);
+
+#[cfg(feature = "stm32g0x1")]
+uart!(
+    LPUART, lpuart, apbenr1, lpuart1en, 256,
+    tx: [
+        (PA2<DefaultMode>, AltFunction::AF6),
+        (PB11<DefaultMode>, AltFunction::AF1),
+        (PC1<DefaultMode>, AltFunction::AF1),
+    ],
+    rx: [
+        (PA3<DefaultMode>, AltFunction::AF6),
+        (PB10<DefaultMode>, AltFunction::AF1),
+        (PC0<DefaultMode>, AltFunction::AF1),
     ],
 );

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -192,14 +192,18 @@ macro_rules! timers {
 
 timers! {
     TIM1: (tim1, tim1en, tim1rst, apbenr2, apbrstr2, cnt),
-    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1, cnt_l, cnt_h),
     TIM3: (tim3, tim3en, tim3rst, apbenr1, apbrstr1, cnt_l, cnt_h),
     TIM14: (tim14, tim14en, tim14rst, apbenr2, apbrstr2, cnt),
     TIM16: (tim16, tim16en, tim16rst, apbenr2, apbrstr2, cnt),
     TIM17: (tim17, tim17en, tim17rst, apbenr2, apbrstr2, cnt),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(feature = "stm32g0x1")]
+timers! {
+    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1, cnt_l, cnt_h),
+}
+
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 timers! {
     TIM6: (tim6, tim6en, tim6rst, apbenr1, apbrstr1, cnt),
     TIM7: (tim7, tim7en, tim7rst, apbenr1, apbrstr1, cnt),

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -134,6 +134,7 @@ opm_hal! {
     TIM17: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
 }
 
+//todo probably needs feature switches since not all parts have all these timers
 opm! {
     TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst),
     TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst),
@@ -143,7 +144,7 @@ opm! {
     TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 opm! {
     TIM15: (apbenr2, apbrstr2, tim15, tim15en, tim15rst),
 }

--- a/src/timer/pins.rs
+++ b/src/timer/pins.rs
@@ -76,7 +76,7 @@ timer_pins!(TIM14, [
     (Channel1, PF0<DefaultMode>, AltFunction::AF2),
 ]);
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 timer_pins!(TIM15, [
     (Channel1, PA2<DefaultMode>, AltFunction::AF5),
     (Channel1, PB14<DefaultMode>, AltFunction::AF5),

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -169,7 +169,7 @@ pwm_hal! {
     TIM3: (Channel4, cc4e, ccmr2_output, oc4pe, oc4m, ccr4, ccr4_l, ccr4_h),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 pwm_hal! {
     TIM15: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, ccr1, moe),
 }
@@ -183,7 +183,7 @@ pwm! {
     TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst, arr),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 pwm! {
     TIM15: (apbenr2, apbrstr2, tim15, tim15en, tim15rst, arr),
 }

--- a/src/timer/stopwatch.rs
+++ b/src/timer/stopwatch.rs
@@ -90,14 +90,18 @@ macro_rules! stopwatches {
 
 stopwatches! {
     TIM1: (tim1, tim1en, tim1rst, apbenr2, apbrstr2, cnt),
-    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1, cnt_l, cnt_h),
     TIM3: (tim3, tim3en, tim3rst, apbenr1, apbrstr1, cnt_l, cnt_h),
     TIM14: (tim14, tim14en, tim14rst, apbenr2, apbrstr2, cnt),
     TIM16: (tim16, tim16en, tim16rst, apbenr2, apbrstr2, cnt),
     TIM17: (tim17, tim17en, tim17rst, apbenr2, apbrstr2, cnt),
 }
 
-#[cfg(any(feature = "stm32g07x", feature = "stm32g081"))]
+#[cfg(feature = "stm32g0x1")]
+stopwatches! {
+    TIM2: (tim2, tim2en, tim2rst, apbenr1, apbrstr1, cnt_l, cnt_h),
+}
+
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 stopwatches! {
     TIM6: (tim6, tim6en, tim6rst, apbenr1, apbrstr1, cnt),
     TIM7: (tim7, tim7en, tim7rst, apbenr1, apbrstr1, cnt),


### PR DESCRIPTION
Replace with `stm32g070` or `stm32g071` or both. This is a first attempt to solve issue https://github.com/stm32-rs/stm32g0xx-hal/issues/18. 

Do you guys think it makes sense like this? 

WIP do not merge yet