### PR TITLE
Use updated PACs and make sure the crate compiles for each part

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ path = "../stm32-rs/stm32g0"
 features = ["rt"]
 
 [dependencies.bare-metal]
-# features = ["const-fn"]
 version = "1.0.0"
 
 [dependencies.embedded-hal]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ features = ["stm32g081", "rt"]
 default-target = "thumbv6m-none-eabi"
 
 [dependencies]
-cortex-m = "0.6.1"
+cortex-m = "0.6.3"
 nb = "0.1.1"
-as-slice = "0.1.2"
+as-slice = "0.1.3"
 
 [dependencies.stm32g0]
 path = "../stm32-rs/stm32g0"
@@ -31,7 +31,7 @@ version = "0.2.5"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.3"
+version = "0.2.4"
 
 [dependencies.void]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ nb = "0.1.1"
 as-slice = "0.1.3"
 
 [dependencies.stm32g0]
-path = "../stm32-rs/stm32g0"
+git = "https://github.com/stm32-rs/stm32-rs-nightlies"
 # version = "0.12.0"
 features = ["rt"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ path = "../stm32-rs/stm32g0"
 features = ["rt"]
 
 [dependencies.bare-metal]
-features = ["const-fn"]
-version = "0.2.5"
+# features = ["const-fn"]
+version = "1.0.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,12 @@ default-target = "thumbv6m-none-eabi"
 [dependencies]
 cortex-m = "0.6.1"
 nb = "0.1.1"
-stm32g0 = "0.10.0"
 as-slice = "0.1.2"
+
+[dependencies.stm32g0]
+path = "../stm32-rs/stm32g0"
+# version = "0.12.0"
+features = ["rt"]
 
 [dependencies.bare-metal]
 features = ["const-fn"]
@@ -48,19 +52,15 @@ ws2812-spi = {git = "https://github.com/smart-leds-rs/ws2812-spi-rs"}
 
 [features]
 rt = ["stm32g0/rt"]
-
 stm32g030 = ["stm32g0/stm32g030", "stm32g0x0"]
-stm32g070 = ["stm32g0/stm32g07x", "stm32g0x0"]
+stm32g070 = ["stm32g0/stm32g070", "stm32g0x0"]
 stm32g031 = ["stm32g0/stm32g031", "stm32g0x1"]
 stm32g041 = ["stm32g0/stm32g041", "stm32g0x1"]
-stm32g071 = ["stm32g0/stm32g07x", "stm32g0x1"]
+stm32g071 = ["stm32g0/stm32g071", "stm32g0x1"]
 stm32g081 = ["stm32g0/stm32g081", "stm32g0x1"]
 
 stm32g0x0 = []
 stm32g0x1 = []
-
-# deprecated, map to "stm32g071" for now
-stm32g07x = ["stm32g0/stm32g07x", "stm32g071"]
 
 [profile.dev]
 incremental = false

--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -8,6 +8,14 @@ extern crate cortex_m_rt as rt;
 extern crate panic_halt;
 extern crate stm32g0xx_hal as hal;
 
+#[cfg(not(any(
+    feature = "stm32g041",
+    feature = "stm32g081"
+)))]
+compile_error!(
+    "Only stm32g041 and stm32g081 have the RNG peripheral"
+);
+
 use cortex_m_semihosting::hprintln;
 use hal::prelude::*;
 use hal::rng::Config;

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -3,6 +3,14 @@
 #![no_main]
 #![no_std]
 
+#[cfg(not(any(
+    feature = "stm32g071",
+    feature = "stm32g081"
+)))]
+compile_error!(
+    "Only stm32g071 and stm32g081 have the DAC peripheral"
+);
+
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
 extern crate panic_halt;

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -24,7 +24,11 @@ fn main() -> ! {
 
     let mut delay = cp.SYST.delay(&mut rcc);
     let mut timer = dp.TIM17.timer(&mut rcc);
+
+    #[cfg(feature = "stm32g0x1")]
     let mut stopwatch = dp.TIM2.stopwatch(&mut rcc);
+    #[cfg(feature = "stm32g0x0")] // TODO: not tested yet with TIM3
+    let mut stopwatch = dp.TIM3.stopwatch(&mut rcc);
 
     let elapsed_us = stopwatch.trace(|| {
         delay.delay(10.us());

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -241,10 +241,10 @@ macro_rules! dma {
 
 dma! {
     DMA: (dmaen, dma1rst, {
-        Channel1: ( ccr1, cndtr1, cpar1, cmar1, cgif0 ),
-        Channel2: ( ccr2, cndtr2, cpar2, cmar2, cgif4 ),
-        Channel3: ( ccr3, cndtr3, cpar3, cmar3, cgif8 ),
-        Channel4: ( ccr4, cndtr4, cpar4, cmar4, cgif12 ),
-        Channel5: ( ccr5, cndtr5, cpar5, cmar5, cgif16 ),
+        Channel1: ( ccr1, cndtr1, cpar1, cmar1, cgif1 ),
+        Channel2: ( ccr2, cndtr2, cpar2, cmar2, cgif2 ),
+        Channel3: ( ccr3, cndtr3, cpar3, cmar3, cgif3 ),
+        Channel4: ( ccr4, cndtr4, cpar4, cmar4, cgif4 ),
+        Channel5: ( ccr5, cndtr5, cpar5, cmar5, cgif5 ),
     }),
 }

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -103,14 +103,9 @@ impl ExtiExt for EXTI {
     }
 
     fn wakeup(&self, ev: Event) {
-        #[cfg(any(feature = "stm32g030", feature = "stm32g031", feature = "stm32g041"))]
+        #[cfg(any(feature = "stm32g030", feature = "stm32g070", feature = "stm32g031", feature = "stm32g041"))]
         self.imr1
             .modify(|r, w| unsafe { w.bits(r.bits() | 1 << ev as u8) });
-
-        // TODO: For some reason this is different between PACs:
-        // imr1 vs imr1(). I think it is an SVD bug
-        #[cfg(feature = "stm32g070")]
-        self.imr1.modify(|r, w| unsafe { w.bits(r.bits() | 1 << ev as u8) });
 
         #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
         match ev as u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,6 @@ pub use nb::block;
 #[cfg(feature = "stm32g030")]
 pub use stm32g0::stm32g030 as stm32;
 
-#[cfg(feature = "stm32g070")]
-pub use stm32g0::stm32g07x as stm32;  // TODO will be stm32g070, to be fixed in next pac release
 
 #[cfg(feature = "stm32g031")]
 pub use stm32g0::stm32g031 as stm32;
@@ -36,15 +34,20 @@ pub use stm32g0::stm32g031 as stm32;
 pub use stm32g0::stm32g041 as stm32;
 
 #[cfg(feature = "stm32g071")]
-pub use stm32g0::stm32g07x as stm32; // TODO will be stm32g071, to be fixed in next pac release
+pub use stm32g0::stm32g071 as stm32;
 
 #[cfg(feature = "stm32g081")]
 pub use stm32g0::stm32g081 as stm32;
+
+
+#[cfg(feature = "stm32g070")]
+pub use stm32g0::stm32g070 as stm32;
 
 #[cfg(feature = "rt")]
 pub use crate::stm32::interrupt;
 
 pub mod analog;
+// TODO fix
 // #[cfg(any(feature = "stm32g071", feature = "stm32g081"))]
 // pub mod comparator;
 pub mod crc;
@@ -55,6 +58,7 @@ pub mod gpio;
 pub mod i2c;
 pub mod prelude;
 pub mod rcc;
+#[cfg(any(feature = "stm32g041", feature = "stm32g081"))]
 pub mod rng;
 pub mod rtc;
 pub mod serial;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,7 +23,9 @@ pub use crate::i2c::I2cExt as _;
 pub use crate::rcc::LSCOExt as _;
 pub use crate::rcc::MCOExt as _;
 pub use crate::rcc::RccExt as _;
+#[cfg(any(feature = "stm32g041", feature = "stm32g081"))]
 pub use crate::rng::RngCore as _;
+#[cfg(any(feature = "stm32g041", feature = "stm32g081"))]
 pub use crate::rng::RngExt as _;
 pub use crate::rtc::RtcExt as _;
 pub use crate::serial::SerialExt as _;

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -138,7 +138,6 @@ opm_hal! {
     TIM2: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr_l, arr_h),
 }
 
-//todo probably needs feature switches since not all parts have all these timers
 opm! {
     TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst),
     TIM3: (apbenr1, apbrstr1, tim3, tim3en, tim3rst),

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -121,10 +121,6 @@ opm_hal! {
     TIM1: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr),
     TIM1: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr),
     TIM1: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr),
-    TIM2: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr_l, arr_h),
-    TIM2: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr_l, arr_h),
-    TIM2: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr_l, arr_h),
-    TIM2: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr_l, arr_h),
     TIM3: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr_l, arr_h),
     TIM3: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr_l, arr_h),
     TIM3: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr_l, arr_h),
@@ -134,14 +130,26 @@ opm_hal! {
     TIM17: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
 }
 
+#[cfg(feature = "stm32g0x1")]
+opm_hal! {
+    TIM2: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr_l, arr_h),
+    TIM2: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr_l, arr_h),
+    TIM2: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr_l, arr_h),
+    TIM2: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr_l, arr_h),
+}
+
 //todo probably needs feature switches since not all parts have all these timers
 opm! {
     TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst),
-    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst),
     TIM3: (apbenr1, apbrstr1, tim3, tim3en, tim3rst),
     TIM14: (apbenr2, apbrstr2, tim14, tim14en, tim14rst),
     TIM16: (apbenr2, apbrstr2, tim16, tim16en, tim16rst),
     TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst),
+}
+
+#[cfg(feature = "stm32g0x1")]
+opm! {
+    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst),
 }
 
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]

--- a/src/timer/pins.rs
+++ b/src/timer/pins.rs
@@ -40,6 +40,7 @@ timer_pins!(TIM1, [
     (Channel4, PC11<DefaultMode>, AltFunction::AF2),
 ]);
 
+#[cfg(feature = "stm32g0x1")]
 timer_pins!(TIM2, [
     (Channel1, PA0<DefaultMode>, AltFunction::AF2),
     (Channel1, PA5<DefaultMode>, AltFunction::AF2),

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -158,11 +158,15 @@ pwm_hal! {
     TIM17: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, ccr1, moe),
 }
 
+#[cfg(feature = "stm32g0x1")]
 pwm_hal! {
     TIM2: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, ccr1, ccr1_l, ccr1_h),
     TIM2: (Channel2, cc2e, ccmr1_output, oc2pe, oc2m, ccr2, ccr2_l, ccr2_h),
     TIM2: (Channel3, cc3e, ccmr2_output, oc3pe, oc3m, ccr3, ccr3_l, ccr3_h),
     TIM2: (Channel4, cc4e, ccmr2_output, oc4pe, oc4m, ccr4, ccr4_l, ccr4_h),
+}
+
+pwm_hal! {
     TIM3: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, ccr1, ccr1_l, ccr1_h),
     TIM3: (Channel2, cc2e, ccmr1_output, oc2pe, oc2m, ccr2, ccr2_l, ccr2_h),
     TIM3: (Channel3, cc3e, ccmr2_output, oc3pe, oc3m, ccr3, ccr3_l, ccr3_h),
@@ -176,11 +180,15 @@ pwm_hal! {
 
 pwm! {
     TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst, arr),
-    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst, arr_l, arr_h),
     TIM3: (apbenr1, apbrstr1, tim3, tim3en, tim3rst, arr_l, arr_h),
     TIM14: (apbenr2, apbrstr2, tim14, tim14en, tim14rst, arr),
     TIM16: (apbenr2, apbrstr2, tim16, tim16en, tim16rst, arr),
     TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst, arr),
+}
+
+#[cfg(feature = "stm32g0x1")]
+pwm! {
+    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst, arr_l, arr_h),
 }
 
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]

--- a/src/timer/qei.rs
+++ b/src/timer/qei.rs
@@ -1,7 +1,12 @@
 //! Quadrature Encoder Interface
 use crate::hal::{self, Direction};
 use crate::rcc::Rcc;
+
+#[cfg(feature = "stm32g0x1")]
 use crate::stm32::{TIM1, TIM2, TIM3};
+#[cfg(feature = "stm32g0x0")]
+use crate::stm32::{TIM1, TIM3};
+
 use crate::timer::pins::TimerPin;
 use crate::timer::*;
 
@@ -103,6 +108,10 @@ macro_rules! qei {
 
 qei! {
     TIM1: (tim1,  tim1en, tim1rst, apbenr2, apbrstr2, arr, cnt),
-    TIM2: (tim2,  tim2en, tim2rst, apbenr1, apbrstr1, arr_l, cnt_l),
     TIM3: (tim3,  tim3en, tim3rst, apbenr1, apbrstr1, arr_l, cnt_l),
+}
+
+#[cfg(feature = "stm32g0x1")]
+qei! {
+    TIM2: (tim2,  tim2en, tim2rst, apbenr1, apbrstr1, arr_l, cnt_l),
 }


### PR DESCRIPTION
~~**Do not merge yet!**~~

This PR updates the PAC `stm32g0` and makes sure the crate compiles for each part.

Certain peripherals are not available for all parts (e.g. RNG, TIM2).
Feature guards now makes sure we don't try to access non-existing
peripherals.

This commit still depends on a local version of `stm32-rs/stm32g0` since the pull request https://github.com/stm32-rs/stm32-rs/pull/398 has not landed yet. After it is merged this PR can depend on the nightlies until they release v0.12.0

I will also try to update the other dependencies in `Cargo.toml`