### PR TITLE
gpio: Fix default pin configuration

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use crate::rcc::Rcc;
 
 /// Default pin mode
-pub type DefaultMode = Input<Floating>;
+pub type DefaultMode = Analog;
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
@@ -87,7 +87,7 @@ macro_rules! gpio {
             /// GPIO parts
             pub struct Parts {
                 $(
-                    pub $pxi: $PXi<Input<Floating>>,
+                    pub $pxi: $PXi<DefaultMode>,
                 )+
             }
 
@@ -189,9 +189,9 @@ macro_rules! gpio {
                     }
                 }
 
-                impl Into<$PXi<Analog>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Analog> {
-                        self.into_analog()
+                impl Into<$PXi<Input<Floating>>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Input<Floating>> {
+                        self.into_floating_input()
                     }
                 }
 


### PR DESCRIPTION
Hi,

according to both g0x0 and g0x1 doc, the default pin configuration is `Analog`.

![MODER](https://user-images.githubusercontent.com/30824037/98946332-0a65dc80-24f4-11eb-8d2a-a066ae68ce92.png)
