### PR TITLE
ADC: Implement calibration

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -17,13 +17,17 @@ use rt::entry;
 #[entry]
 fn main() -> ! {
     let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    let cp = stm32::CorePeripherals::take().expect("cannot take core peripherals");
     let mut rcc = dp.RCC.constrain();
+    let mut delay = cp.SYST.delay(&mut rcc);
 
     let gpioa = dp.GPIOA.split(&mut rcc);
 
     let mut adc = dp.ADC.constrain(&mut rcc);
     adc.set_sample_time(SampleTime::T_80);
     adc.set_precision(Precision::B_12);
+    delay.delay(20.us()); // Wait for ADC voltage regulator to stabilize
+    adc.calibrate();
 
     let mut adc_pin = gpioa.pa0.into_analog();
     let mut vtemp = VTemp::new();

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -68,6 +68,17 @@ impl Adc {
         }
     }
 
+    /// Runs the calibration routine on the ADC
+    ///
+    /// Wait for tADCVREG_SETUP (20us on STM32G071x8) after calling `new()`
+    /// before calibrating, to wait for the ADC voltage regulator to stabilize.
+    ///
+    /// Do not call if an ADC reading is ongoing.
+    pub fn calibrate(&mut self) {
+        self.rb.cr.modify(|_, w| w.adcal().set_bit());
+        while self.rb.cr.read().adcal().bit_is_set() {}
+    }
+
     /// Set the Adc sampling time
     pub fn set_sample_time(&mut self, t_samp: SampleTime) {
         self.sample_time = t_samp;


### PR DESCRIPTION
Still need to test this on real hardware. (Dev board should be arriving today or tomorrow).

20us is not very long and calibration is not run very often (once?) so we could just do the delay in `new` or `calibrate`