### PR TITLE
UART: add Tx/Rx pin swapping

### DIFF
--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -60,6 +60,7 @@ pub struct BasicConfig {
     pub(crate) wordlength: WordLength,
     pub(crate) parity: Parity,
     pub(crate) stopbits: StopBits,
+    pub(crate) swap: bool,
 }
 
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
@@ -68,6 +69,7 @@ pub struct FullConfig {
     pub(crate) wordlength: WordLength,
     pub(crate) parity: Parity,
     pub(crate) stopbits: StopBits,
+    pub(crate) swap: bool,
     pub(crate) fifo_enable: bool,
     pub(crate) tx_fifo_threshold: FifoThreshold,
     pub(crate) rx_fifo_threshold: FifoThreshold,
@@ -112,6 +114,14 @@ impl BasicConfig {
         self.stopbits = stopbits;
         self
     }
+
+    /// Swap the Tx/Rx pins
+    ///
+    /// The peripheral will transmit on the pin given as the `rx` argument.
+    pub fn swap_pins(mut self) -> Self {
+        self.swap = true;
+        self
+    }
 }
 
 impl FullConfig {
@@ -147,6 +157,14 @@ impl FullConfig {
 
     pub fn stopbits(mut self, stopbits: StopBits) -> Self {
         self.stopbits = stopbits;
+        self
+    }
+
+    /// Swap the Tx/Rx pins
+    ///
+    /// The peripheral will transmit on the pin given as the `rx` argument.
+    pub fn swap_pins(mut self) -> Self {
+        self.swap = true;
         self
     }
 
@@ -194,6 +212,7 @@ impl Default for BasicConfig {
             wordlength: WordLength::DataBits8,
             parity: Parity::ParityNone,
             stopbits: StopBits::STOP1,
+            swap: false,
         }
     }
 }
@@ -206,6 +225,7 @@ impl Default for FullConfig {
             wordlength: WordLength::DataBits8,
             parity: Parity::ParityNone,
             stopbits: StopBits::STOP1,
+            swap: false,
             fifo_enable: false,
             tx_fifo_threshold: FifoThreshold::FIFO_8_BYTES,
             rx_fifo_threshold: FifoThreshold::FIFO_8_BYTES,

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -380,12 +380,15 @@ macro_rules! uart_basic {
                         .bit(config.parity == Parity::ParityOdd)
                 });
                 usart.cr2.write(|w| unsafe {
-                    w.stop().bits(match config.stopbits {
-                        StopBits::STOP1 => 0b00,
-                        StopBits::STOP0P5 => 0b01,
-                        StopBits::STOP2 => 0b10,
-                        StopBits::STOP1P5 => 0b11,
-                    })
+                    w.stop()
+                        .bits(match config.stopbits {
+                            StopBits::STOP1 => 0b00,
+                            StopBits::STOP0P5 => 0b01,
+                            StopBits::STOP2 => 0b10,
+                            StopBits::STOP1P5 => 0b11,
+                        })
+                        .swap()
+                        .bit(config.swap)
                 });
 
                 // Enable USART
@@ -490,9 +493,12 @@ macro_rules! uart_full {
                 usart.cr2.reset();
                 usart.cr3.reset();
 
-                usart
-                    .cr2
-                    .write(|w| unsafe { w.stop().bits(config.stopbits.bits()) });
+                usart.cr2.write(|w| unsafe {
+                    w.stop()
+                        .bits(config.stopbits.bits())
+                        .swap()
+                        .bit(config.swap)
+                });
 
                 if let Some(timeout) = config.receiver_timeout {
                     usart.cr1.write(|w| w.rtoie().set_bit());


### PR DESCRIPTION
The alternative is to `impl TxPin` for all the Rx pins, etc. I think this version is more obvious in the documentation vs listing even more traits.