### PR TITLE
Support PWM output on inverted CHx pins

### DIFF
--- a/src/timer/pins.rs
+++ b/src/timer/pins.rs
@@ -39,6 +39,18 @@ timer_pins!(TIM1, [
     (Channel4, PA11<DefaultMode>, AltFunction::AF2),
     (Channel4, PC11<DefaultMode>, AltFunction::AF2),
 ]);
+// Inverted pins
+timer_pins!(TIM1, [
+    (Channel1, PA7<DefaultMode>, AltFunction::AF2),
+    (Channel1, PB13<DefaultMode>, AltFunction::AF2),
+    (Channel1, PD2<DefaultMode>, AltFunction::AF2),
+    (Channel2, PB0<DefaultMode>, AltFunction::AF2),
+    (Channel2, PB14<DefaultMode>, AltFunction::AF2),
+    (Channel2, PD3<DefaultMode>, AltFunction::AF2),
+    (Channel3, PB1<DefaultMode>, AltFunction::AF2),
+    (Channel3, PB15<DefaultMode>, AltFunction::AF2),
+    (Channel3, PD4<DefaultMode>, AltFunction::AF2),
+]);
 
 #[cfg(feature = "stm32g0x1")]
 timer_pins!(TIM2, [
@@ -83,6 +95,16 @@ timer_pins!(TIM15, [
     (Channel1, PA2<DefaultMode>, AltFunction::AF5),
     (Channel1, PB14<DefaultMode>, AltFunction::AF5),
     (Channel1, PC1<DefaultMode>, AltFunction::AF2),
+    (Channel2, PA3<DefaultMode>, AltFunction::AF5),
+    (Channel2, PB15<DefaultMode>, AltFunction::AF5),
+    (Channel2, PC2<DefaultMode>, AltFunction::AF2),
+]);
+// Inverted pins
+#[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
+timer_pins!(TIM15, [
+    (Channel1, PA1<DefaultMode>, AltFunction::AF5),
+    (Channel1, PB13<DefaultMode>, AltFunction::AF5),
+    (Channel1, PF1<DefaultMode>, AltFunction::AF2),
 ]);
 
 timer_pins!(TIM16, [
@@ -90,9 +112,17 @@ timer_pins!(TIM16, [
     (Channel1, PB8<DefaultMode>, AltFunction::AF2),
     (Channel1, PD0<DefaultMode>, AltFunction::AF2),
 ]);
+// Inverted pins
+timer_pins!(TIM16, [
+    (Channel1, PB6<DefaultMode>, AltFunction::AF2),
+]);
 
 timer_pins!(TIM17, [
     (Channel1, PA7<DefaultMode>, AltFunction::AF6),
     (Channel1, PB9<DefaultMode>, AltFunction::AF2),
     (Channel1, PD1<DefaultMode>, AltFunction::AF2),
+]);
+//  Inverted pins
+timer_pins!(TIM17, [
+    (Channel1, PB7<DefaultMode>, AltFunction::AF2),
 ]);


### PR DESCRIPTION
And add a few missing non-inverted TIM15 pins.

The inverted outputs are the same as the non-inverted outputs, except they are inverted of course. Since inverted and non-inverted outputs never share the same physical pin, I think it's reasonable that the inversion should be considered at the hardware level. Therefore we don't need to build an additional abstraction for inversion in the HAL, and the straightforward implementation here is just fine.