### PR TITLE
Change DAC functionality in EnabledUnbuffered mode

### DIFF
--- a/src/analog/dac.rs
+++ b/src/analog/dac.rs
@@ -122,7 +122,7 @@ macro_rules! dac {
                 pub fn enable_unbuffered(self) -> $CX<EnabledUnbuffered> {
                     let dac = unsafe { &(*DAC::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(3) });
+                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(2) });
                     dac.dac_cr.modify(|_, w| w.$en().set_bit());
 
                     $CX {


### PR DESCRIPTION
Previously MCR.MODE[12] = 3, which corresponds to "connected to on chip peripherals with buffer disabled". In this case the DAC output is not connected to the pin, which is quite unexpected.

Change to MCR.MODE[12] = 2, which corresponds to "connected to external pin with buffer disabled". This provides the expected functionality.

Perhaps it would be useful to support connecting the DAC to on-chip peripherals, but that should be available separately to the choice of buffered/unbuffered.