### PR TITLE
new ADC with trigger from timer and use of 2xdma

### DIFF
--- a/examples/adc_ext_trig_double_dma_serial.rs
+++ b/examples/adc_ext_trig_double_dma_serial.rs
@@ -1,0 +1,211 @@
+// has been tested on nucleo-32 with STM32G031
+// command build: cargo build --example adc_ext_trig_double_dma_serial --features stm32g031
+// command run: cargo run --example adc_ext_trig_double_dma_serial --features stm32g031
+
+#![deny(warnings)]
+// #![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+use cortex_m_semihosting::{ hprintln};
+
+extern crate nb;
+extern crate panic_halt;
+extern crate stm32g0xx_hal as hal;
+extern crate stm32g0;
+
+
+use hal::prelude::*;
+use hal::stm32;
+use hal::serial::*;
+use rt::entry;
+
+use core::cell::{RefCell};
+use cortex_m::{ interrupt::Mutex};
+
+use crate::hal::{
+    stm32::{interrupt, Interrupt},
+};
+use hal::analog::adc::{Precision, SampleTime, InjTrigSource}; //, VTemp
+
+use hal::dma::{self, Channel, Target};
+
+use crate::hal::analog::adc::InjectMode;
+use crate::hal::analog::adc::DmaMode;
+
+// Make dma globally available
+static G_DMA: Mutex<RefCell<Option<hal::dma::Channels>>> = Mutex::new(RefCell::new(None));
+
+const BUFFER_SIZE: u16 = 4;
+// Make the buffer pointer globally available
+static G_DMA_BUFFER_ADDR: Mutex<RefCell<Option<u32>>> = Mutex::new(RefCell::new(None));
+
+#[interrupt]
+fn DMA_CHANNEL1() {
+    static mut DMA: Option<hal::dma::Channels> = None;
+    static mut DMA_BUFFER_ADDR: Option<u32> = None;
+
+    let dma_ch = DMA.get_or_insert_with(|| {
+        cortex_m::interrupt::free(|cs| {
+            // Move dma here, leaving a None in its place
+            G_DMA.borrow(cs).replace(None).unwrap()
+        })
+    });
+
+    let dma_buf_addr = DMA_BUFFER_ADDR.get_or_insert_with(|| {
+        cortex_m::interrupt::free(|cs| {
+            // Move dma buffer pointer here, leaving a None in its place
+            G_DMA_BUFFER_ADDR.borrow(cs).replace(None).unwrap()
+        })
+    });
+    
+    let tx_dma_buf_first_addr: u32 = *dma_buf_addr;
+    let tx_dma_buf_second_addr: u32 = *dma_buf_addr + (BUFFER_SIZE) as u32; 
+    // Address is in byte, value in 2Bytes, this is why second dma buffer ist added with BUFFER_SIZE 
+    // and not BUFFER_SIZE/2
+    
+    
+    unsafe {
+        let dma = &(*stm32g0::stm32g031::DMA::ptr());
+        let htif1 = dma.isr.read().htif1().bit();
+        let tcif1 = dma.isr.read().tcif1().bit();
+        // set the global clear bit of DMA channel1
+        dma.ifcr.write(|w| w.cgif1().set_bit());
+
+        dma_ch.ch2.disable();
+        dma_ch.ch2.set_transfer_length(BUFFER_SIZE as u16);
+        if htif1 == true {
+            dma_ch.ch2.set_memory_address(tx_dma_buf_first_addr, true);
+            dma_ch.ch2.enable();
+            // hprintln!("DMA_CHANNEL1 half transfer compleated {:?} {:?}", htif1, tx_dma_buf_first_addr).unwrap();
+        } else if tcif1 == true {
+            dma_ch.ch2.set_memory_address(tx_dma_buf_second_addr, true);
+            dma_ch.ch2.enable();
+            // hprintln!("DMA_CHANNEL1 transfer compleated {:?}  {:?}", tcif1, tx_dma_buf_second_addr).unwrap();
+        }
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    let mut rcc = dp.RCC.constrain();
+
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    let mut timer = dp.TIM2.timer(&mut rcc);
+
+    let usart1 = dp
+        .USART1
+        .usart(
+            gpioa.pa9,  // TX: pa9, => CN3 Pin-D5
+            gpioa.pa10, // RX: pa10, => CN3 Pin-D4
+            FullConfig::default().baudrate(460800.bps())
+            .fifo_enable(),  // enable fifo, so that dma can fill it fast, otherwise it may not finish before ch1 is requested again
+            &mut rcc,
+        )
+        .unwrap();
+
+    // DMA example
+    //==================================================
+    let adc_buffer1: [u16; BUFFER_SIZE as usize] = [0;BUFFER_SIZE as usize];
+
+    let mut dma = dp.DMA.split(&mut rcc, dp.DMAMUX);
+
+    let adc_ptr = unsafe { &(*stm32g0::stm32g031::ADC::ptr()) };
+    let adc_data_register_addr = &adc_ptr.dr as *const _ as u32;
+
+    let adc_buffer1_addr: u32 = adc_buffer1.as_ptr() as u32;
+
+    dma.ch1.set_word_size(dma::WordSize::BITS16);
+    dma.ch1.set_direction(dma::Direction::FromPeripheral);
+    dma.ch1.set_memory_address(adc_buffer1_addr, true);
+    dma.ch1.set_peripheral_address(adc_data_register_addr, false);
+    dma.ch1.set_transfer_length(adc_buffer1.len() as u16);
+    
+    hprintln!("adc_data_register_addr {:?}", adc_buffer1_addr).unwrap(); // will output addr in dec
+    // in gdb read the data bytes with:  x /32xh 0x???????   (last is addr in hex) 
+    // or put addr in dec format:   x /32xh 536878092
+    // https://sourceware.org/gdb/current/onlinedocs/gdb/Memory.html
+
+    // dma ch1 reads from ADC register into memory
+    dma.ch1.select_peripheral(stm32g0xx_hal::dmamux::DmaMuxIndex::ADC);
+    // The dma continuesly fills the buffer, when its full, it starts over again
+    dma.ch1.set_circular_mode(true);
+
+    // Enabel dma irq for half and full buffer, when reached, so that the second dma ch2 can be started
+    dma.ch1.listen(hal::dma::Event::HalfTransfer);
+    dma.ch1.listen(hal::dma::Event::TransferComplete);
+
+    let (mut tx, mut _rx) = usart1.split();
+
+    let usart = unsafe { &(*stm32::USART1::ptr()) };
+    let tx_data_register_addr = &usart.tdr as *const _ as u32;
+
+    dma.ch2.set_direction(dma::Direction::FromMemory);
+    dma.ch2.set_peripheral_address(tx_data_register_addr, false);
+    dma.ch2.set_word_size(hal::dma::WordSize::BITS8);
+
+    dma.ch2.select_peripheral(tx.dmamux());
+
+    tx.enable_dma();
+
+    // start dma transfer
+    dma.ch1.enable();
+
+    cortex_m::interrupt::free(|cs| *G_DMA.borrow(cs).borrow_mut() = Some(dma));
+    cortex_m::interrupt::free(|cs| *G_DMA_BUFFER_ADDR.borrow(cs).borrow_mut() = Some(adc_buffer1_addr));
+    
+    
+
+    //==================================================
+    // Set up adc
+
+    let mut adc = dp.ADC.constrain(&mut rcc);
+    adc.set_sample_time(SampleTime::T_80);
+    adc.set_precision(Precision::B_12);
+    let mut pa3 = gpioa.pa5.into_analog();
+    let u_raw: u32 = adc.read(&mut pa3).expect("adc read failed");
+    let u = u_raw.saturating_sub(32) as f32 / 4_096_f32 * 3.3;
+    hprintln!("u: {:.4} V ", u).unwrap();
+
+    adc.set_oversamling_ratio(3);
+    adc.set_oversamling_shift(4);
+    adc.oversamling_enable();
+    adc.prepare_injected(&mut pa3, InjTrigSource::TRG_2);
+    adc.start_injected();
+
+
+    // Enable timer to trigger external sources in mms value of cr2
+    // 011: Compare Pulse - The trigger output send a positive pulse when the CC1IF flag is to be
+    // set (even if it was already high), as soon as a capture or a compare match occurred.
+    // ouput is (TRGO)
+    // according to reference manual chapter 22.4.2
+    // this is only available on timer TIM2, TIM3, TIM4 and TIM1
+    unsafe{
+        // get pointer of timer 2
+        let tim = &(*stm32g0::stm32g031::TIM2::ptr());
+        // 
+        tim.cr2.modify(|_,w|  w.mms().bits(3 as u8));   
+    }
+
+    // enable dma to be called, when adc is ready to read
+    adc.dma_enable(true);
+    adc.dma_circualr_mode(true);
+
+    // don't enabel the timer bevor the dma
+    // Set up a timer expiring after 
+    timer.start(50.us());
+    timer.listen();
+
+    //enable DMA_CHANNEL1 interrupt
+    unsafe {
+        cortex_m::peripheral::NVIC::unmask(Interrupt::DMA_CHANNEL1);
+    }
+
+    loop {
+        
+    }
+}

--- a/examples/adc_ext_trig_double_dma_serial.rs
+++ b/examples/adc_ext_trig_double_dma_serial.rs
@@ -9,31 +9,28 @@
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
-use cortex_m_semihosting::{ hprintln};
+use cortex_m_semihosting::hprintln;
 
 extern crate nb;
 extern crate panic_halt;
-extern crate stm32g0xx_hal as hal;
 extern crate stm32g0;
-
+extern crate stm32g0xx_hal as hal;
 
 use hal::prelude::*;
-use hal::stm32;
 use hal::serial::*;
+use hal::stm32;
 use rt::entry;
 
-use core::cell::{RefCell};
-use cortex_m::{ interrupt::Mutex};
+use core::cell::RefCell;
+use cortex_m::interrupt::Mutex;
 
-use crate::hal::{
-    stm32::{interrupt, Interrupt},
-};
-use hal::analog::adc::{Precision, SampleTime, InjTrigSource}; //, VTemp
+use crate::hal::stm32::{interrupt, Interrupt};
+use hal::analog::adc::{InjTrigSource, Precision, SampleTime}; //, VTemp
 
 use hal::dma::{self, Channel, Target};
 
-use crate::hal::analog::adc::InjectMode;
 use crate::hal::analog::adc::DmaMode;
+use crate::hal::analog::adc::InjectMode;
 
 // Make dma globally available
 static G_DMA: Mutex<RefCell<Option<hal::dma::Channels>>> = Mutex::new(RefCell::new(None));
@@ -60,13 +57,12 @@ fn DMA_CHANNEL1() {
             G_DMA_BUFFER_ADDR.borrow(cs).replace(None).unwrap()
         })
     });
-    
+
     let tx_dma_buf_first_addr: u32 = *dma_buf_addr;
-    let tx_dma_buf_second_addr: u32 = *dma_buf_addr + (BUFFER_SIZE) as u32; 
-    // Address is in byte, value in 2Bytes, this is why second dma buffer ist added with BUFFER_SIZE 
+    let tx_dma_buf_second_addr: u32 = *dma_buf_addr + (BUFFER_SIZE) as u32;
+    // Address is in byte, value in 2Bytes, this is why second dma buffer ist added with BUFFER_SIZE
     // and not BUFFER_SIZE/2
-    
-    
+
     unsafe {
         let dma = &(*stm32g0::stm32g031::DMA::ptr());
         let htif1 = dma.isr.read().htif1().bit();
@@ -100,17 +96,16 @@ fn main() -> ! {
     let usart1 = dp
         .USART1
         .usart(
-            gpioa.pa9,  // TX: pa9, => CN3 Pin-D5
-            gpioa.pa10, // RX: pa10, => CN3 Pin-D4
-            FullConfig::default().baudrate(460800.bps())
-            .fifo_enable(),  // enable fifo, so that dma can fill it fast, otherwise it may not finish before ch1 is requested again
+            gpioa.pa9,                                                  // TX: pa9, => CN3 Pin-D5
+            gpioa.pa10,                                                 // RX: pa10, => CN3 Pin-D4
+            FullConfig::default().baudrate(460800.bps()).fifo_enable(), // enable fifo, so that dma can fill it fast, otherwise it may not finish before ch1 is requested again
             &mut rcc,
         )
         .unwrap();
 
     // DMA example
     //==================================================
-    let adc_buffer1: [u16; BUFFER_SIZE as usize] = [0;BUFFER_SIZE as usize];
+    let adc_buffer1: [u16; BUFFER_SIZE as usize] = [0; BUFFER_SIZE as usize];
 
     let mut dma = dp.DMA.split(&mut rcc, dp.DMAMUX);
 
@@ -122,16 +117,18 @@ fn main() -> ! {
     dma.ch1.set_word_size(dma::WordSize::BITS16);
     dma.ch1.set_direction(dma::Direction::FromPeripheral);
     dma.ch1.set_memory_address(adc_buffer1_addr, true);
-    dma.ch1.set_peripheral_address(adc_data_register_addr, false);
+    dma.ch1
+        .set_peripheral_address(adc_data_register_addr, false);
     dma.ch1.set_transfer_length(adc_buffer1.len() as u16);
-    
+
     hprintln!("adc_data_register_addr {:?}", adc_buffer1_addr).unwrap(); // will output addr in dec
-    // in gdb read the data bytes with:  x /32xh 0x???????   (last is addr in hex) 
-    // or put addr in dec format:   x /32xh 536878092
-    // https://sourceware.org/gdb/current/onlinedocs/gdb/Memory.html
+                                                                         // in gdb read the data bytes with:  x /32xh 0x???????   (last is addr in hex)
+                                                                         // or put addr in dec format:   x /32xh 536878092
+                                                                         // https://sourceware.org/gdb/current/onlinedocs/gdb/Memory.html
 
     // dma ch1 reads from ADC register into memory
-    dma.ch1.select_peripheral(stm32g0xx_hal::dmamux::DmaMuxIndex::ADC);
+    dma.ch1
+        .select_peripheral(stm32g0xx_hal::dmamux::DmaMuxIndex::ADC);
     // The dma continuesly fills the buffer, when its full, it starts over again
     dma.ch1.set_circular_mode(true);
 
@@ -156,9 +153,9 @@ fn main() -> ! {
     dma.ch1.enable();
 
     cortex_m::interrupt::free(|cs| *G_DMA.borrow(cs).borrow_mut() = Some(dma));
-    cortex_m::interrupt::free(|cs| *G_DMA_BUFFER_ADDR.borrow(cs).borrow_mut() = Some(adc_buffer1_addr));
-    
-    
+    cortex_m::interrupt::free(|cs| {
+        *G_DMA_BUFFER_ADDR.borrow(cs).borrow_mut() = Some(adc_buffer1_addr)
+    });
 
     //==================================================
     // Set up adc
@@ -177,18 +174,17 @@ fn main() -> ! {
     adc.prepare_injected(&mut pa3, InjTrigSource::TRG_2);
     adc.start_injected();
 
-
     // Enable timer to trigger external sources in mms value of cr2
     // 011: Compare Pulse - The trigger output send a positive pulse when the CC1IF flag is to be
     // set (even if it was already high), as soon as a capture or a compare match occurred.
     // ouput is (TRGO)
     // according to reference manual chapter 22.4.2
     // this is only available on timer TIM2, TIM3, TIM4 and TIM1
-    unsafe{
+    unsafe {
         // get pointer of timer 2
         let tim = &(*stm32g0::stm32g031::TIM2::ptr());
-        // 
-        tim.cr2.modify(|_,w|  w.mms().bits(3 as u8));   
+        //
+        tim.cr2.modify(|_, w| w.mms().bits(3 as u8));
     }
 
     // enable dma to be called, when adc is ready to read
@@ -196,7 +192,7 @@ fn main() -> ! {
     adc.dma_circualr_mode(true);
 
     // don't enabel the timer bevor the dma
-    // Set up a timer expiring after 
+    // Set up a timer expiring after
     timer.start(50.us());
     timer.listen();
 
@@ -205,7 +201,5 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(Interrupt::DMA_CHANNEL1);
     }
 
-    loop {
-        
-    }
+    loop {}
 }

--- a/examples/adc_ext_trig_double_dma_serial.rs
+++ b/examples/adc_ext_trig_double_dma_serial.rs
@@ -9,28 +9,31 @@
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
-use cortex_m_semihosting::hprintln;
+use cortex_m_semihosting::{ hprintln};
 
 extern crate nb;
 extern crate panic_halt;
-extern crate stm32g0;
 extern crate stm32g0xx_hal as hal;
+extern crate stm32g0;
+
 
 use hal::prelude::*;
-use hal::serial::*;
 use hal::stm32;
+use hal::serial::*;
 use rt::entry;
 
-use core::cell::RefCell;
-use cortex_m::interrupt::Mutex;
+use core::cell::{RefCell};
+use cortex_m::{ interrupt::Mutex};
 
-use crate::hal::stm32::{interrupt, Interrupt};
-use hal::analog::adc::{InjTrigSource, Precision, SampleTime}; //, VTemp
+use crate::hal::{
+    stm32::{interrupt, Interrupt},
+};
+use hal::analog::adc::{Precision, SampleTime, InjTrigSource}; //, VTemp
 
 use hal::dma::{self, Channel, Target};
 
-use crate::hal::analog::adc::DmaMode;
 use crate::hal::analog::adc::InjectMode;
+use crate::hal::analog::adc::DmaMode;
 
 // Make dma globally available
 static G_DMA: Mutex<RefCell<Option<hal::dma::Channels>>> = Mutex::new(RefCell::new(None));
@@ -57,12 +60,13 @@ fn DMA_CHANNEL1() {
             G_DMA_BUFFER_ADDR.borrow(cs).replace(None).unwrap()
         })
     });
-
+    
     let tx_dma_buf_first_addr: u32 = *dma_buf_addr;
-    let tx_dma_buf_second_addr: u32 = *dma_buf_addr + (BUFFER_SIZE) as u32;
-    // Address is in byte, value in 2Bytes, this is why second dma buffer ist added with BUFFER_SIZE
+    let tx_dma_buf_second_addr: u32 = *dma_buf_addr + (BUFFER_SIZE) as u32; 
+    // Address is in byte, value in 2Bytes, this is why second dma buffer ist added with BUFFER_SIZE 
     // and not BUFFER_SIZE/2
-
+    
+    
     unsafe {
         let dma = &(*stm32g0::stm32g031::DMA::ptr());
         let htif1 = dma.isr.read().htif1().bit();
@@ -96,16 +100,17 @@ fn main() -> ! {
     let usart1 = dp
         .USART1
         .usart(
-            gpioa.pa9,                                                  // TX: pa9, => CN3 Pin-D5
-            gpioa.pa10,                                                 // RX: pa10, => CN3 Pin-D4
-            FullConfig::default().baudrate(460800.bps()).fifo_enable(), // enable fifo, so that dma can fill it fast, otherwise it may not finish before ch1 is requested again
+            gpioa.pa9,  // TX: pa9, => CN3 Pin-D5
+            gpioa.pa10, // RX: pa10, => CN3 Pin-D4
+            FullConfig::default().baudrate(460800.bps())
+            .fifo_enable(),  // enable fifo, so that dma can fill it fast, otherwise it may not finish before ch1 is requested again
             &mut rcc,
         )
         .unwrap();
 
     // DMA example
     //==================================================
-    let adc_buffer1: [u16; BUFFER_SIZE as usize] = [0; BUFFER_SIZE as usize];
+    let adc_buffer1: [u16; BUFFER_SIZE as usize] = [0;BUFFER_SIZE as usize];
 
     let mut dma = dp.DMA.split(&mut rcc, dp.DMAMUX);
 
@@ -117,18 +122,16 @@ fn main() -> ! {
     dma.ch1.set_word_size(dma::WordSize::BITS16);
     dma.ch1.set_direction(dma::Direction::FromPeripheral);
     dma.ch1.set_memory_address(adc_buffer1_addr, true);
-    dma.ch1
-        .set_peripheral_address(adc_data_register_addr, false);
+    dma.ch1.set_peripheral_address(adc_data_register_addr, false);
     dma.ch1.set_transfer_length(adc_buffer1.len() as u16);
-
+    
     hprintln!("adc_data_register_addr {:?}", adc_buffer1_addr).unwrap(); // will output addr in dec
-                                                                         // in gdb read the data bytes with:  x /32xh 0x???????   (last is addr in hex)
-                                                                         // or put addr in dec format:   x /32xh 536878092
-                                                                         // https://sourceware.org/gdb/current/onlinedocs/gdb/Memory.html
+    // in gdb read the data bytes with:  x /32xh 0x???????   (last is addr in hex) 
+    // or put addr in dec format:   x /32xh 536878092
+    // https://sourceware.org/gdb/current/onlinedocs/gdb/Memory.html
 
     // dma ch1 reads from ADC register into memory
-    dma.ch1
-        .select_peripheral(stm32g0xx_hal::dmamux::DmaMuxIndex::ADC);
+    dma.ch1.select_peripheral(stm32g0xx_hal::dmamux::DmaMuxIndex::ADC);
     // The dma continuesly fills the buffer, when its full, it starts over again
     dma.ch1.set_circular_mode(true);
 
@@ -153,9 +156,9 @@ fn main() -> ! {
     dma.ch1.enable();
 
     cortex_m::interrupt::free(|cs| *G_DMA.borrow(cs).borrow_mut() = Some(dma));
-    cortex_m::interrupt::free(|cs| {
-        *G_DMA_BUFFER_ADDR.borrow(cs).borrow_mut() = Some(adc_buffer1_addr)
-    });
+    cortex_m::interrupt::free(|cs| *G_DMA_BUFFER_ADDR.borrow(cs).borrow_mut() = Some(adc_buffer1_addr));
+    
+    
 
     //==================================================
     // Set up adc
@@ -174,17 +177,18 @@ fn main() -> ! {
     adc.prepare_injected(&mut pa3, InjTrigSource::TRG_2);
     adc.start_injected();
 
+
     // Enable timer to trigger external sources in mms value of cr2
     // 011: Compare Pulse - The trigger output send a positive pulse when the CC1IF flag is to be
     // set (even if it was already high), as soon as a capture or a compare match occurred.
     // ouput is (TRGO)
     // according to reference manual chapter 22.4.2
     // this is only available on timer TIM2, TIM3, TIM4 and TIM1
-    unsafe {
+    unsafe{
         // get pointer of timer 2
         let tim = &(*stm32g0::stm32g031::TIM2::ptr());
-        //
-        tim.cr2.modify(|_, w| w.mms().bits(3 as u8));
+        // 
+        tim.cr2.modify(|_,w|  w.mms().bits(3 as u8));   
     }
 
     // enable dma to be called, when adc is ready to read
@@ -192,7 +196,7 @@ fn main() -> ! {
     adc.dma_circualr_mode(true);
 
     // don't enabel the timer bevor the dma
-    // Set up a timer expiring after
+    // Set up a timer expiring after 
     timer.start(50.us());
     timer.listen();
 
@@ -201,5 +205,7 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(Interrupt::DMA_CHANNEL1);
     }
 
-    loop {}
+    loop {
+        
+    }
 }

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -75,15 +75,16 @@ pub enum AsyncClockDiv {
 /// ADC injected trigger source selection
 #[derive(Copy, Clone, PartialEq)]
 pub enum InjTrigSource {
-    TRG_0 = 0b000, // TIM1_TRGO2
-    TRG_1 = 0b001, // TIM1_CC4
-    TRG_2 = 0b010, // TIM2_TRGO
-    TRG_3 = 0b011, // TIM3_TRGO
-    TRG_4 = 0b100, // TIM15_TRGO
-    TRG_5 = 0b101, // TIM6_TRGO
-    TRG_6 = 0b110, // TIM4_TRGO
-    TRG_7 = 0b111, // EXTI11
+    TRG_0 = 0b000,   // TIM1_TRGO2
+    TRG_1 = 0b001,   // TIM1_CC4
+    TRG_2 = 0b010,   // TIM2_TRGO
+    TRG_3 = 0b011,   // TIM3_TRGO
+    TRG_4 = 0b100,   // TIM15_TRGO
+    TRG_5 = 0b101,   // TIM6_TRGO
+    TRG_6 = 0b110,   // TIM4_TRGO
+    TRG_7 = 0b111,   // EXTI11
 }
+
 
 /// Analog to Digital converter interface
 pub struct Adc {
@@ -193,10 +194,8 @@ impl Adc {
     }
 
     /// The nuber of bits, the oversampling result is shifted in bits at the end of oversampling
-    pub fn set_oversamling_shift(&mut self, nrbits: u8) {
-        self.rb
-            .cfgr2
-            .modify(|_, w| unsafe { w.ovss().bits(nrbits) });
+    pub fn set_oversamling_shift(&mut self, nrbits:u8) {
+        self.rb.cfgr2.modify(|_, w| unsafe {w.ovss().bits(nrbits)});
     }
 
     /// Oversampling of adc according to datasheet of stm32g0, when oversampling is enabled
@@ -209,27 +208,25 @@ impl Adc {
     /// 110: 128x
     /// 111: 256x
 
-    pub fn set_oversamling_ratio(&mut self, multyply: u8) {
-        self.rb
-            .cfgr2
-            .modify(|_, w| unsafe { w.ovsr().bits(multyply) });
+    pub fn set_oversamling_ratio(&mut self, multyply:u8) {
+        self.rb.cfgr2.modify(|_, w| unsafe {w.ovsr().bits(multyply)});
     }
 
     pub fn oversamling_enable(&mut self) {
-        self.rb.cfgr2.modify(|_, w| unsafe { w.ovse().set_bit() });
+        self.rb.cfgr2.modify(|_, w| unsafe {w.ovse().set_bit()});
     }
 
     pub fn start_injected(&mut self) {
-        self.rb.cr.modify(|_, w| w.adstart().set_bit());
+        self.rb.cr.modify(|_,w|  w.adstart().set_bit());
         // ADSTART bit is cleared to 0 bevor using this function
         // enable self.rb.isr.eos() flag is set after each converstion
         self.rb.ier.modify(|_, w| w.eocie().set_bit()); // end of sequence interupt enable
     }
 
-    pub fn stop_injected(&mut self) {
-        // ?????? or is it reset after each conversion?
+
+    pub fn stop_injected(&mut self) {  // ?????? or is it reset after each conversion?
         // ADSTART bit is cleared to 0 bevor using this function
-        // disable EOS interrupt
+        // disable EOS interrupt 
         // maybe self.rb.cr.adstp().set_bit() must be performed before interrupt is disabled + wait abortion
         self.rb.ier.modify(|_, w| w.eocie().clear_bit()); // end of sequence interupt disable
     }
@@ -258,32 +255,39 @@ where
 {
     type Error = ();
 
-    fn prepare_injected(&mut self, _pin: &mut PIN, triger_source: InjTrigSource) {
-        // set the clock mode to synchronous one
+    fn prepare_injected(&mut self, _pin: &mut PIN, triger_source: InjTrigSource){
+        // set the clock mode to synchronous one 
         // self.rb.cfgr2.ckmode().bits(CLCOKMODE)   // CLOCKMODE = 01 or 10 for PCLK/2 or PCLK/4
 
+        
         // self.set_injected_trigger_source(triger_source as InjTrigSource);
-        self.rb
-            .cfgr1
-            .modify(|_, w| unsafe { w.exten().bits(1).extsel().bits(triger_source as u8) });
+        self.rb.cfgr1.modify(|_, w| unsafe {
+            w.exten()
+                .bits(1)
+                .extsel()
+                .bits(triger_source as u8)
+        });
 
         self.rb.cfgr1.modify(|_, w| unsafe {
-            w.res() // set ADC resolution bits (ADEN must be =0)
+            w.res()   // set ADC resolution bits (ADEN must be =0)
                 .bits(self.precision as u8)
-                .align() // set alignment bit is  (ADSTART must be 0)
+                .align()    // set alignment bit is  (ADSTART must be 0)
                 .bit(self.align == Align::Left)
         });
 
         self.power_up();
 
         self.rb
-            .smpr // set sampling time set 1 (ADSTART must be 0)
+            .smpr  // set sampling time set 1 (ADSTART must be 0) 
             .modify(|_, w| unsafe { w.smp1().bits(self.sample_time as u8) });
 
         self.rb
-            .chselr() // set activ channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
+            .chselr()  // set activ channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
             .modify(|_, w| unsafe { w.chsel().bits(1 << PIN::channel()) });
+
     }
+
+    
 }
 
 pub trait DmaMode<ADC> {
@@ -294,24 +298,26 @@ pub trait DmaMode<ADC> {
 }
 
 impl DmaMode<Adc> for Adc {
+
     type Error = ();
 
     fn dma_enable(&mut self, enable: bool) {
         if enable {
-            self.rb.cfgr1.modify(|_, w| w.dmaen().set_bit()); //  enable dma beeing called
+            self.rb.cfgr1.modify(|_,w| w.dmaen().set_bit());   //  enable dma beeing called
         } else {
-            self.rb.cfgr1.modify(|_, w| w.dmaen().clear_bit()); //  disable dma beeing called
+            self.rb.cfgr1.modify(|_,w| w.dmaen().clear_bit());   //  disable dma beeing called
         }
     }
-
+    
     fn dma_circualr_mode(&mut self, enable: bool) {
         if enable {
-            self.rb.cfgr1.modify(|_, w| w.dmacfg().set_bit()); // activate circular mode
+            self.rb.cfgr1.modify(|_,w| w.dmacfg().set_bit());  // activate circular mode
         } else {
-            self.rb.cfgr1.modify(|_, w| w.dmacfg().clear_bit()); // disable circular mode
+            self.rb.cfgr1.modify(|_,w| w.dmacfg().clear_bit());  // disable circular mode
         }
     }
 }
+
 
 impl<WORD, PIN> OneShot<Adc, WORD, PIN> for Adc
 where

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -75,16 +75,15 @@ pub enum AsyncClockDiv {
 /// ADC injected trigger source selection
 #[derive(Copy, Clone, PartialEq)]
 pub enum InjTrigSource {
-    TRG_0 = 0b000,   // TIM1_TRGO2
-    TRG_1 = 0b001,   // TIM1_CC4
-    TRG_2 = 0b010,   // TIM2_TRGO
-    TRG_3 = 0b011,   // TIM3_TRGO
-    TRG_4 = 0b100,   // TIM15_TRGO
-    TRG_5 = 0b101,   // TIM6_TRGO
-    TRG_6 = 0b110,   // TIM4_TRGO
-    TRG_7 = 0b111,   // EXTI11
+    TRG_0 = 0b000, // TIM1_TRGO2
+    TRG_1 = 0b001, // TIM1_CC4
+    TRG_2 = 0b010, // TIM2_TRGO
+    TRG_3 = 0b011, // TIM3_TRGO
+    TRG_4 = 0b100, // TIM15_TRGO
+    TRG_5 = 0b101, // TIM6_TRGO
+    TRG_6 = 0b110, // TIM4_TRGO
+    TRG_7 = 0b111, // EXTI11
 }
-
 
 /// Analog to Digital converter interface
 pub struct Adc {
@@ -194,8 +193,10 @@ impl Adc {
     }
 
     /// The nuber of bits, the oversampling result is shifted in bits at the end of oversampling
-    pub fn set_oversamling_shift(&mut self, nrbits:u8) {
-        self.rb.cfgr2.modify(|_, w| unsafe {w.ovss().bits(nrbits)});
+    pub fn set_oversamling_shift(&mut self, nrbits: u8) {
+        self.rb
+            .cfgr2
+            .modify(|_, w| unsafe { w.ovss().bits(nrbits) });
     }
 
     /// Oversampling of adc according to datasheet of stm32g0, when oversampling is enabled
@@ -208,25 +209,27 @@ impl Adc {
     /// 110: 128x
     /// 111: 256x
 
-    pub fn set_oversamling_ratio(&mut self, multyply:u8) {
-        self.rb.cfgr2.modify(|_, w| unsafe {w.ovsr().bits(multyply)});
+    pub fn set_oversamling_ratio(&mut self, multyply: u8) {
+        self.rb
+            .cfgr2
+            .modify(|_, w| unsafe { w.ovsr().bits(multyply) });
     }
 
     pub fn oversamling_enable(&mut self) {
-        self.rb.cfgr2.modify(|_, w| unsafe {w.ovse().set_bit()});
+        self.rb.cfgr2.modify(|_, w| unsafe { w.ovse().set_bit() });
     }
 
     pub fn start_injected(&mut self) {
-        self.rb.cr.modify(|_,w|  w.adstart().set_bit());
+        self.rb.cr.modify(|_, w| w.adstart().set_bit());
         // ADSTART bit is cleared to 0 bevor using this function
         // enable self.rb.isr.eos() flag is set after each converstion
         self.rb.ier.modify(|_, w| w.eocie().set_bit()); // end of sequence interupt enable
     }
 
-
-    pub fn stop_injected(&mut self) {  // ?????? or is it reset after each conversion?
+    pub fn stop_injected(&mut self) {
+        // ?????? or is it reset after each conversion?
         // ADSTART bit is cleared to 0 bevor using this function
-        // disable EOS interrupt 
+        // disable EOS interrupt
         // maybe self.rb.cr.adstp().set_bit() must be performed before interrupt is disabled + wait abortion
         self.rb.ier.modify(|_, w| w.eocie().clear_bit()); // end of sequence interupt disable
     }
@@ -255,39 +258,32 @@ where
 {
     type Error = ();
 
-    fn prepare_injected(&mut self, _pin: &mut PIN, triger_source: InjTrigSource){
-        // set the clock mode to synchronous one 
+    fn prepare_injected(&mut self, _pin: &mut PIN, triger_source: InjTrigSource) {
+        // set the clock mode to synchronous one
         // self.rb.cfgr2.ckmode().bits(CLCOKMODE)   // CLOCKMODE = 01 or 10 for PCLK/2 or PCLK/4
 
-        
         // self.set_injected_trigger_source(triger_source as InjTrigSource);
-        self.rb.cfgr1.modify(|_, w| unsafe {
-            w.exten()
-                .bits(1)
-                .extsel()
-                .bits(triger_source as u8)
-        });
+        self.rb
+            .cfgr1
+            .modify(|_, w| unsafe { w.exten().bits(1).extsel().bits(triger_source as u8) });
 
         self.rb.cfgr1.modify(|_, w| unsafe {
-            w.res()   // set ADC resolution bits (ADEN must be =0)
+            w.res() // set ADC resolution bits (ADEN must be =0)
                 .bits(self.precision as u8)
-                .align()    // set alignment bit is  (ADSTART must be 0)
+                .align() // set alignment bit is  (ADSTART must be 0)
                 .bit(self.align == Align::Left)
         });
 
         self.power_up();
 
         self.rb
-            .smpr  // set sampling time set 1 (ADSTART must be 0) 
+            .smpr // set sampling time set 1 (ADSTART must be 0)
             .modify(|_, w| unsafe { w.smp1().bits(self.sample_time as u8) });
 
         self.rb
-            .chselr()  // set activ channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
+            .chselr() // set activ channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
             .modify(|_, w| unsafe { w.chsel().bits(1 << PIN::channel()) });
-
     }
-
-    
 }
 
 pub trait DmaMode<ADC> {
@@ -298,26 +294,24 @@ pub trait DmaMode<ADC> {
 }
 
 impl DmaMode<Adc> for Adc {
-
     type Error = ();
 
     fn dma_enable(&mut self, enable: bool) {
         if enable {
-            self.rb.cfgr1.modify(|_,w| w.dmaen().set_bit());   //  enable dma beeing called
+            self.rb.cfgr1.modify(|_, w| w.dmaen().set_bit()); //  enable dma beeing called
         } else {
-            self.rb.cfgr1.modify(|_,w| w.dmaen().clear_bit());   //  disable dma beeing called
+            self.rb.cfgr1.modify(|_, w| w.dmaen().clear_bit()); //  disable dma beeing called
         }
     }
-    
+
     fn dma_circualr_mode(&mut self, enable: bool) {
         if enable {
-            self.rb.cfgr1.modify(|_,w| w.dmacfg().set_bit());  // activate circular mode
+            self.rb.cfgr1.modify(|_, w| w.dmacfg().set_bit()); // activate circular mode
         } else {
-            self.rb.cfgr1.modify(|_,w| w.dmacfg().clear_bit());  // disable circular mode
+            self.rb.cfgr1.modify(|_, w| w.dmacfg().clear_bit()); // disable circular mode
         }
     }
 }
-
 
 impl<WORD, PIN> OneShot<Adc, WORD, PIN> for Adc
 where

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -168,7 +168,7 @@ pub trait Channel: private::Channel {
     }
 
     /// Set the word size.
-    fn set_word_size<W>(&mut self, wsize: WordSize) {
+    fn set_word_size(&mut self, wsize: WordSize) {
         self.ch().cr.modify(|_, w| unsafe {
             w.psize().bits(wsize as u8);
             w.msize().bits(wsize as u8)


### PR DESCRIPTION
Some extensions to ADC with:
- Two traits added (Injection Mode and DMA enable)

example that uses them:
- externel trigger of the ADC from TIM2
- DMA to transfer data from ADC to Memory
- DMA to transfer data from Memory-Buffer to UART
- UART in buffer mode
- oversampling is enabled by 16 and a bit shift is configured too

Tested with Nucleo32 STM32G031

The configuration of TIM2 is still included in the example, I was not able to change it only for the timers, which support that function