### PR TITLE
Make uart-dma example do repeated transfers

### DIFF
--- a/examples/uart-dma.rs
+++ b/examples/uart-dma.rs
@@ -7,7 +7,7 @@ extern crate stm32g0xx_hal as hal;
 
 use core::fmt::Write;
 
-use hal::dma::{self, Channel, Target};
+use hal::dma::{self, Channel, Target, Event};
 use hal::prelude::*;
 use hal::serial::*;
 use hal::stm32;
@@ -19,6 +19,9 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().expect("cannot take peripherals");
     let mut rcc = dp.RCC.constrain();
     let gpioa = dp.GPIOA.split(&mut rcc);
+    let gpiob = dp.GPIOB.split(&mut rcc);
+
+    let mut led = gpioa.pa5.into_push_pull_output();
 
     let mut usart1 = dp
         .USART1
@@ -38,6 +41,7 @@ fn main() -> ! {
 
     let mut dma = dp.DMA.split(&mut rcc, dp.DMAMUX);
 
+    // Setup DMA for USART1 TX with dma channel 1.
     let usart = unsafe { &(*stm32::USART1::ptr()) };
     let tx_data_register_addr = &usart.tdr as *const _ as u32;
     let tx_dma_buf_addr: u32 = tx_buffer.as_ptr() as u32;
@@ -47,12 +51,43 @@ fn main() -> ! {
     dma.ch1.set_peripheral_address(tx_data_register_addr, false);
     dma.ch1.set_transfer_length(tx_buffer.len() as u16);
 
+    // Configure dmamux for dma ch1 and usart tx
     dma.ch1.select_peripheral(tx.dmamux());
+
+    dma.ch1.listen(Event::TransferComplete);
 
     tx.enable_dma();
     dma.ch1.enable();
 
+
+    // Create a second buffer to send after the first dma transfer has completed
+    let mut tx_buffer2: [u8; 23] = *b"Transfer complete {0}!\n";
+    let tx_dma_buf_addr: u32 = tx_buffer2.as_ptr() as u32;
+
+    let mut delay = dp.TIM1.delay(& mut rcc);
+
     loop {
-        continue;
+        if dma.ch1.event_occurred(Event::TransferComplete) {
+            dma.ch1.clear_event(Event::TransferComplete);
+
+            // update the char between '{ }' in tx_buffer2
+            tx_buffer2[19] += 1;
+
+            // wrap around to ascii value 33 == '!', so that we only use printable characters.
+            if tx_buffer2[19] > 126 {
+                tx_buffer2[19] = 33;
+            }
+
+            dma.ch1.disable();
+
+            led.toggle().unwrap();
+
+
+            dma.ch1.set_memory_address(tx_dma_buf_addr, true);
+            dma.ch1.set_transfer_length(tx_buffer2.len() as u16);
+            dma.ch1.enable();
+        }
+
+        delay.delay(500.ms());
     }
 }

--- a/examples/uart-dma.rs
+++ b/examples/uart-dma.rs
@@ -7,7 +7,7 @@ extern crate stm32g0xx_hal as hal;
 
 use core::fmt::Write;
 
-use hal::dma::{self, Channel, Target, Event};
+use hal::dma::{self, Channel, Event, Target};
 use hal::prelude::*;
 use hal::serial::*;
 use hal::stm32;
@@ -59,12 +59,11 @@ fn main() -> ! {
     tx.enable_dma();
     dma.ch1.enable();
 
-
     // Create a second buffer to send after the first dma transfer has completed
     let mut tx_buffer2: [u8; 23] = *b"Transfer complete {0}!\n";
     let tx_dma_buf_addr: u32 = tx_buffer2.as_ptr() as u32;
 
-    let mut delay = dp.TIM1.delay(& mut rcc);
+    let mut delay = dp.TIM1.delay(&mut rcc);
 
     loop {
         if dma.ch1.event_occurred(Event::TransferComplete) {
@@ -81,7 +80,6 @@ fn main() -> ! {
             dma.ch1.disable();
 
             led.toggle().unwrap();
-
 
             dma.ch1.set_memory_address(tx_dma_buf_addr, true);
             dma.ch1.set_transfer_length(tx_buffer2.len() as u16);


### PR DESCRIPTION
The `uart-dma` example only did one transfer. I have adjusted it to do repeated transfers. However I am not sure if this is the right way to prime a new dma transfer.

Am I supposed to disable and re-enable the dma channel to issue a new transfer?

```rust
dma.ch1.disable();
dma.ch1.set_memory_address(tx_dma_buf_addr, true);
dma.ch1.set_transfer_length(tx_buffer2.len() as u16);
dma.ch1.enable();
```

So far this is the only way I managed to do a next dma transfer. Also setting the transfer length (number of bytes in this case) again seems to be a requirement, which makes sense I guess.

Is there another way besides `dma.ch1.disable()` ? For example when you're using the transfer-half-done event, I think the idea is to do non-stop dma transfers right?

