### PR TITLE
GPIO alternate mode sequence

### DIFF
--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     #[cfg(feature = "stm32g0x1")]
     let mut stopwatch = dp.TIM2.stopwatch(&mut rcc);
-    #[cfg(feature = "stm32g0x0")] // TODO: not tested yet with TIM3
+    #[cfg(feature = "stm32g0x0")]
     let mut stopwatch = dp.TIM3.stopwatch(&mut rcc);
 
     let elapsed_us = stopwatch.trace(|| {

--- a/src/analog/comparator.rs
+++ b/src/analog/comparator.rs
@@ -102,16 +102,6 @@ pub enum Hysteresis {
     High = 0b11,
 }
 
-// TODO
-// pub enum Blanking {
-//     None,
-//     Tim1Oc4(),
-//     Tim1Oc5(),
-//     Tim2Oc3(),
-//     Tim3Oc3(),
-//     Tim15Oc2()<
-// }
-
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum PowerMode {
     HighSpeed = 0b00,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -202,10 +202,6 @@ macro_rules! i2c {
                 let timing_bits = config.timing_bits(rcc.clocks.apb_clk);
                 i2c.timingr.write(|w| unsafe { w.bits(timing_bits) });
 
-                // Enable pins
-                sda.setup();
-                scl.setup();
-
                 // Enable the I2C processing
                 i2c.cr1.modify(|_, w| unsafe {
                     w.pe()
@@ -215,6 +211,10 @@ macro_rules! i2c {
                         .anfoff()
                         .bit(!config.analog_filter)
                 });
+
+                // Enable pins
+                sda.setup();
+                scl.setup();
 
                 I2c { i2c, sda, scl }
             }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -188,10 +188,6 @@ macro_rules! i2c {
                 SDA: SDAPin<$I2CX>,
                 SCL: SCLPin<$I2CX>,
             {
-
-                sda.setup();
-                scl.setup();
-
                 // Enable clock for I2C
                 rcc.rb.apbenr1.modify(|_, w| w.$i2cxen().set_bit());
 
@@ -205,6 +201,10 @@ macro_rules! i2c {
                 // Setup protocol timings
                 let timing_bits = config.timing_bits(rcc.clocks.apb_clk);
                 i2c.timingr.write(|w| unsafe { w.bits(timing_bits) });
+
+                // Enable pins
+                sda.setup();
+                scl.setup();
 
                 // Enable the I2C processing
                 i2c.cr1.modify(|_, w| unsafe {

--- a/src/rcc/clockout.rs
+++ b/src/rcc/clockout.rs
@@ -30,7 +30,6 @@ pub trait LSCOExt {
 
 impl LSCOExt for LscoPin {
     fn lsco(self, src: LSCOSrc, rcc: &mut Rcc) -> Lsco {
-        self.set_alt_mode(AltFunction::AF0);
         let src_select_bit = match src {
             LSCOSrc::LSE => {
                 rcc.enable_lse(false);
@@ -42,6 +41,7 @@ impl LSCOExt for LscoPin {
             }
         };
         rcc.unlock_rtc();
+        self.set_alt_mode(AltFunction::AF0);
         rcc.rb.bdcr.modify(|_, w| w.lscosel().bit(src_select_bit));
         Lsco { pin: self }
     }
@@ -78,8 +78,6 @@ macro_rules! mco {
         $(
             impl MCOExt<$PIN> for $PIN {
                 fn mco(self, src: MCOSrc, psc: Prescaler, rcc: &mut Rcc) -> Mco<$PIN> {
-                    self.set_alt_mode(AltFunction::AF0);
-
                     let psc_bits = match psc {
                         Prescaler::NotDivided => 0b000,
                         Prescaler::Div2 => 0b001,
@@ -90,6 +88,7 @@ macro_rules! mco {
                         Prescaler::Div64 => 0b110,
                         _ => 0b111,
                     };
+
                     rcc.rb.cfgr.modify(|r, w| unsafe {
                         w.bits((r.bits() & !(0b111 << 28)) | (psc_bits << 28))
                     });
@@ -114,6 +113,8 @@ macro_rules! mco {
                             0b111
                         },
                     };
+
+                    self.set_alt_mode(AltFunction::AF0);
                     Mco { src_bits, pin: self }
                 }
             }

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -362,9 +362,6 @@ macro_rules! uart_basic {
                 TX: TxPin<$USARTX>,
                 RX: RxPin<$USARTX>,
             {
-                tx.setup();
-                rx.setup();
-
                 // Enable clock for USART
                 rcc.rb.$apbXenr.modify(|_, w| w.$usartXen().set_bit());
                 let clk = rcc.clocks.apb_clk.0 as u64;
@@ -404,6 +401,10 @@ macro_rules! uart_basic {
                         .swap()
                         .bit(config.swap)
                 });
+
+                // Enable pins
+                tx.setup();
+                rx.setup();
 
                 // Enable USART
                 usart.cr1.modify(|_, w| w.ue().set_bit());
@@ -491,9 +492,6 @@ macro_rules! uart_full {
                 TX: TxPin<$USARTX>,
                 RX: RxPin<$USARTX>,
             {
-                tx.setup();
-                rx.setup();
-
                 // Enable clock for USART
                 rcc.rb.$apbXenr.modify(|_, w| w.$usartXen().set_bit());
 
@@ -549,6 +547,9 @@ macro_rules! uart_full {
                         .fifoen()
                         .bit(config.fifo_enable)
                 });
+
+                tx.setup();
+                rx.setup();
 
                 Ok(Serial {
                     tx: Tx {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -117,8 +117,6 @@ macro_rules! spi {
             PINS: Pins<$SPIX>,
             T: Into<Hertz>
             {
-                pins.setup();
-
                 // Enable clock for SPI
                 rcc.rb.$apbXenr.modify(|_, w| w.$spiXen().set_bit());
                 rcc.rb.$apbXrst.modify(|_, w| w.$spiXrst().set_bit());
@@ -144,6 +142,9 @@ macro_rules! spi {
                 spi.cr2.write(|w| unsafe {
                     w.frxth().set_bit().ds().bits(0b111).ssoe().clear_bit()
                 });
+
+                // Enable pins
+                pins.setup();
 
                 spi.cr1.write(|w| unsafe {
                     w.cpha()
@@ -171,7 +172,6 @@ macro_rules! spi {
                         .spe()
                         .set_bit()
                 });
-
 
                 Spi { spi, pins }
             }

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -37,10 +37,10 @@ macro_rules! opm {
             where
                 PIN: TimerPin<$TIMX>,
             {
-                pin.setup();
                 rcc.rb.$apbXenr.modify(|_, w| w.$timXen().set_bit());
                 rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().set_bit());
                 rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().clear_bit());
+                pin.setup();
                 Opm {
                     rb: tim,
                     clk: rcc.clocks.apb_tim_clk,

--- a/src/timer/qei.rs
+++ b/src/timer/qei.rs
@@ -42,7 +42,6 @@ macro_rules! qei {
         $(
             impl<PINS> Qei<$TIMX, PINS> where PINS: QeiPins<$TIMX> {
                 fn $tim(tim: $TIMX, pins: PINS, rcc: &mut Rcc) -> Self {
-                    pins.setup();
                     // enable and reset peripheral to a clean slate state
                     rcc.rb.$apbenr.modify(|_, w| w.$timXen().set_bit());
                     rcc.rb.$apbrstr.modify(|_, w| w.$timXrst().set_bit());
@@ -71,6 +70,8 @@ macro_rules! qei {
                             .cc2np()
                             .clear_bit()
                     });
+
+                    pins.setup();
 
                     tim.cr1.write(|w| w.cen().set_bit());
                     Qei { tim, pins }


### PR DESCRIPTION
This PR fixed GPIO alternate mode switch sequence: pins must be switched into desired mode only after peripheral got clocks and basic initialization.