### PR TITLE
spi: Fix miso configuration for pb2

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -315,7 +315,7 @@ spi!(
     miso: [
         (PA3<DefaultMode>, AltFunction::AF0),
         (PA9<DefaultMode>, AltFunction::AF4),
-        (PB2<DefaultMode>, AltFunction::AF2),
+        (PB2<DefaultMode>, AltFunction::AF1),
         (PB6<DefaultMode>, AltFunction::AF4),
         (PB14<DefaultMode>, AltFunction::AF0),
         (PC2<DefaultMode>, AltFunction::AF1),


### PR DESCRIPTION
The datasheet shows pb2 SPI2 MISO as AF1, not AF2.

TEST=Wired up an stm32g071 and confirmed that SPI2 with MISO on pb2
worked with this change and didn't work without.