### PR TITLE
Fix I2C timing.

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -55,14 +55,14 @@ impl Config {
         let speed = self.speed.unwrap();
         let (psc, scll, sclh, sdadel, scldel) = if speed.0 <= 100_000 {
             let psc = 3;
-            let scll = cmp::max(((i2c_clk.0 >> (psc + 1)) / speed.0) - 1, 255);
+            let scll = cmp::min((((i2c_clk.0 >> 1) / (psc + 1)) / speed.0) - 1, 255);
             let sclh = scll - 4;
             let sdadel = 2;
             let scldel = 4;
             (psc, scll, sclh, sdadel, scldel)
         } else {
             let psc = 1;
-            let scll = cmp::max(((i2c_clk.0 >> (psc + 1)) / speed.0) - 1, 255);
+            let scll = cmp::min((((i2c_clk.0 >> 1) / (psc + 1)) / speed.0) - 1, 255);
             let sclh = scll - 6;
             let sdadel = 1;
             let scldel = 3;


### PR DESCRIPTION
While stealing this code for stm32g4xx-hal, I noticed that the I2C timing was WAY off.

The std::max() meant that scll was always set to 255, resulting in bit
rates that were far too slow. Also, the documentation states that the
clock is divided by PRESC+1, not by 2^(PRESC+1).

**This code is untested, I do not have any STM32G0xx MCU. I only tested the effects of this patch on a system with an STM32G4xx MCU, where it results in the correct bit rate. AFAICS, the peripherals are identical.**