### PR TITLE
One-Pulse mode refactoring

### DIFF
--- a/examples/opm.rs
+++ b/examples/opm.rs
@@ -15,7 +15,6 @@ use hal::prelude::*;
 use hal::rcc;
 use hal::stm32;
 use hal::timer::opm::Opm;
-use hal::timer::Channel1;
 use rtic::app;
 
 #[app(device = hal::stm32, peripherals = true)]
@@ -23,7 +22,7 @@ const APP: () = {
     struct Resources {
         exti: stm32::EXTI,
         led: PA5<Output<PushPull>>,
-        opm: Opm<stm32::TIM14, Channel1>,
+        opm: Opm<stm32::TIM3>,
     }
 
     #[init]
@@ -32,13 +31,28 @@ const APP: () = {
         let mut exti = ctx.device.EXTI;
 
         let gpioa = ctx.device.GPIOA.split(&mut rcc);
+        let gpiob = ctx.device.GPIOB.split(&mut rcc);
         let gpioc = ctx.device.GPIOC.split(&mut rcc);
 
         let led = gpioa.pa5.into_push_pull_output();
         gpioc.pc13.listen(SignalEdge::Falling, &mut exti);
 
-        let mut opm = ctx.device.TIM14.opm(gpioa.pa4, 5.ms(), &mut rcc);
-        opm.enable();
+        let opm = ctx.device.TIM3.opm(4.ms(), &mut rcc);
+
+        let mut opm_ch1 = opm.bind_pin(gpioa.pa6);
+        opm_ch1.enable();
+
+        let mut opm_ch2 = opm.bind_pin(gpioa.pa7);
+        opm_ch2.set_delay(1.ms());
+        opm_ch2.enable();
+
+        let mut opm_ch3 = opm.bind_pin(gpiob.pb0);
+        opm_ch3.set_delay(2.ms());
+        opm_ch3.enable();
+
+        let mut opm_ch4 = opm.bind_pin(gpiob.pb1);
+        opm_ch4.set_delay(3.ms());
+        opm_ch4.enable();
 
         init::LateResources { opm, exti, led }
     }

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -8,45 +8,72 @@ use crate::timer::*;
 use core::marker::PhantomData;
 
 pub trait OpmExt: Sized {
-    fn opm<PIN>(self, _: PIN, pulse_width: MicroSecond, rcc: &mut Rcc) -> Opm<Self, PIN::Channel>
-    where
-        PIN: TimerPin<Self>;
+    fn opm(self, period: MicroSecond, rcc: &mut Rcc) -> Opm<Self>;
 }
 
-pub struct Opm<TIM, CHANNEL> {
-    rb: TIM,
+pub struct OpmPin<TIM, CH> {
+    tim: PhantomData<TIM>,
+    channel: PhantomData<CH>,
     clk: Hertz,
-    pulse_width: MicroSecond,
     delay: MicroSecond,
-    _channel: PhantomData<CHANNEL>,
+}
+
+pub struct Opm<TIM> {
+    tim: PhantomData<TIM>,
+    clk: Hertz,
+}
+
+impl<TIM> Opm<TIM> {
+    pub fn bind_pin<PIN>(&self, pin: PIN) -> OpmPin<TIM, PIN::Channel>
+    where
+        PIN: TimerPin<TIM>,
+    {
+        pin.setup();
+        OpmPin {
+            tim: PhantomData,
+            channel: PhantomData,
+            clk: self.clk,
+            delay: 0.ms(),
+        }
+    }
 }
 
 macro_rules! opm {
-    ($($TIMX:ident: ($apbXenr:ident, $apbXrstr:ident, $timX:ident, $timXen:ident, $timXrst:ident),)+) => {
+    ($($TIMX:ident: ($apbXenr:ident, $apbXrstr:ident, $timX:ident, $timXen:ident, $timXrst:ident, $arr:ident $(,$arr_h:ident)*),)+) => {
         $(
             impl OpmExt for $TIMX {
-                fn opm<PIN>(self, pin: PIN, pulse_width: MicroSecond, rcc: &mut Rcc) -> Opm<Self, PIN::Channel>
-                where
-                    PIN: TimerPin<Self>
-                {
-                    $timX(self, pin, pulse_width, rcc)
+                fn opm(self, period: MicroSecond, rcc: &mut Rcc) -> Opm<Self> {
+                    $timX(self, period, rcc)
                 }
             }
 
-            fn $timX<PIN>(tim: $TIMX, pin: PIN, pulse_width: MicroSecond, rcc: &mut Rcc) -> Opm<$TIMX, PIN::Channel>
-            where
-                PIN: TimerPin<$TIMX>,
-            {
+            fn $timX(tim: $TIMX, period: MicroSecond, rcc: &mut Rcc) -> Opm<$TIMX> {
                 rcc.rb.$apbXenr.modify(|_, w| w.$timXen().set_bit());
                 rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().set_bit());
                 rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().clear_bit());
-                pin.setup();
+
+                let cycles_per_period = rcc.clocks.apb_tim_clk / period.into();
+                let psc = (cycles_per_period - 1) / 0xffff;
+                tim.psc.write(|w| unsafe { w.psc().bits(psc as u16) });
+
+                let freq = (rcc.clocks.apb_tim_clk.0 / (psc + 1)).hz();
+                let reload = period.cycles(freq);
+                unsafe {
+                    tim.arr.write(|w| w.$arr().bits(reload as u16));
+                    $(
+                        tim.arr.modify(|_, w| w.$arr_h().bits((reload >> 16) as u16));
+                    )*
+                }
                 Opm {
-                    rb: tim,
-                    clk: rcc.clocks.apb_tim_clk,
-                    pulse_width,
-                    delay: 0.us(),
-                    _channel: PhantomData,
+                    clk: freq,
+                    tim: PhantomData,
+                }
+            }
+
+            impl Opm<$TIMX> {
+                pub fn generate(&mut self) {
+                    let tim =  unsafe {&*$TIMX::ptr()};
+                    tim.cr1.write(|w| w.opm().set_bit().cen().set_bit());
                 }
             }
         )+
@@ -55,32 +82,22 @@ macro_rules! opm {
 
 macro_rules! opm_hal {
     ($($TIMX:ident:
-        ($CH:ty, $ccxe:ident, $ccmrx_output:ident, $ocxm:ident, $ocxfe:ident, $ccrx:ident, $arr:ident $(,$arr_h:ident)*),)+
+        ($CH:ty, $ccxe:ident, $ccmrx_output:ident, $ocxm:ident, $ocxfe:ident, $ccrx:ident),)+
     ) => {
         $(
-            impl Opm<$TIMX, $CH> {
-                pub fn enable (&mut self) {
-                    self.rb.ccer.modify(|_, w| w.$ccxe().set_bit());
+            impl OpmPin<$TIMX, $CH> {
+                pub fn enable(&mut self) {
+                    let tim =  unsafe {&*$TIMX::ptr()};
+                    tim.ccer.modify(|_, w| w.$ccxe().set_bit());
                     self.setup();
                 }
 
-                pub fn disable (&mut self) {
-                    self.rb.ccer.modify(|_, w| w.$ccxe().clear_bit());
+                pub fn disable(&mut self) {
+                    let tim =  unsafe {&*$TIMX::ptr()};
+                    tim.ccer.modify(|_, w| w.$ccxe().clear_bit());
                 }
 
-                pub fn generate(&mut self) {
-                    self.rb.cr1.write(|w| w.opm().set_bit().cen().set_bit());
-                }
-
-                pub fn set_pulse_width<T> (&mut self, pulse_width: T)
-                where
-                    T: Into<MicroSecond>
-                {
-                    self.pulse_width = pulse_width.into();
-                    self.setup();
-                }
-
-                pub fn set_delay<T> (&mut self, delay: T)
+                pub fn set_delay<T>(&mut self, delay: T)
                 where
                     T: Into<MicroSecond>
                 {
@@ -88,27 +105,16 @@ macro_rules! opm_hal {
                     self.setup();
                 }
 
-                fn setup (&mut self) {
-                    let period = self.pulse_width + self.delay;
-
-                    let cycles_per_period = self.clk / period.into();
-                    let psc = (cycles_per_period - 1) / 0xffff;
-
-                    self.rb.psc.write(|w| unsafe { w.psc().bits(psc as u16) });
-                    let freq = (self.clk.0 / (psc + 1)).hz();
-                    let reload = cycles_per_period / (psc + 1);
+                fn setup(&mut self) {
+                    let tim =  unsafe {&*$TIMX::ptr()};
                     let compare = if self.delay.0 > 0 {
-                        self.delay.cycles(freq)
+                        self.delay.cycles(self.clk)
                     } else {
                         1
                     };
                     unsafe {
-                        self.rb.arr.write(|w| w.$arr().bits(reload as u16));
-                        self.rb.$ccrx.write(|w| w.bits(compare));
-                        $(
-                            self.rb.arr.modify(|_, w| w.$arr_h().bits((reload >> 16) as u16));
-                        )*
-                        self.rb.$ccmrx_output().modify(|_, w| w.$ocxm().bits(7).$ocxfe().set_bit());
+                        tim.$ccrx.write(|w| w.bits(compare));
+                        tim.$ccmrx_output().modify(|_, w| w.$ocxm().bits(7).$ocxfe().set_bit());
                     }
                 }
             }
@@ -117,41 +123,41 @@ macro_rules! opm_hal {
 }
 
 opm_hal! {
-    TIM1: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
-    TIM1: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr),
-    TIM1: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr),
-    TIM1: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr),
-    TIM3: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr_l, arr_h),
-    TIM3: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr_l, arr_h),
-    TIM3: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr_l, arr_h),
-    TIM3: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr_l, arr_h),
-    TIM14: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
-    TIM16: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
-    TIM17: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr),
+    TIM1: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM1: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2),
+    TIM1: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3),
+    TIM1: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4),
+    TIM3: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM3: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2),
+    TIM3: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3),
+    TIM3: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4),
+    TIM14: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM16: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM17: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
 }
 
 #[cfg(feature = "stm32g0x1")]
 opm_hal! {
-    TIM2: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1, arr_l, arr_h),
-    TIM2: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2, arr_l, arr_h),
-    TIM2: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3, arr_l, arr_h),
-    TIM2: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4, arr_l, arr_h),
+    TIM2: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM2: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2),
+    TIM2: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3),
+    TIM2: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4),
 }
 
 opm! {
-    TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst),
-    TIM3: (apbenr1, apbrstr1, tim3, tim3en, tim3rst),
-    TIM14: (apbenr2, apbrstr2, tim14, tim14en, tim14rst),
-    TIM16: (apbenr2, apbrstr2, tim16, tim16en, tim16rst),
-    TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst),
+    TIM1: (apbenr2, apbrstr2, tim1, tim1en, tim1rst, arr),
+    TIM3: (apbenr1, apbrstr1, tim3, tim3en, tim3rst, arr_l, arr_h),
+    TIM14: (apbenr2, apbrstr2, tim14, tim14en, tim14rst, arr),
+    TIM16: (apbenr2, apbrstr2, tim16, tim16en, tim16rst, arr),
+    TIM17: (apbenr2, apbrstr2, tim17, tim17en, tim17rst, arr),
 }
 
 #[cfg(feature = "stm32g0x1")]
 opm! {
-    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst),
+    TIM2: (apbenr1, apbrstr1, tim2, tim2en, tim2rst, arr_l, arr_h),
 }
 
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 opm! {
-    TIM15: (apbenr2, apbrstr2, tim15, tim15en, tim15rst),
+    TIM15: (apbenr2, apbrstr2, tim15, tim15en, tim15rst, arr),
 }

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -97,11 +97,8 @@ macro_rules! opm_hal {
                     tim.ccer.modify(|_, w| w.$ccxe().clear_bit());
                 }
 
-                pub fn set_delay<T>(&mut self, delay: T)
-                where
-                    T: Into<MicroSecond>
-                {
-                    self.delay = delay.into();
+                pub fn set_delay(&mut self, delay: MicroSecond) {
+                    self.delay = delay;
                     self.setup();
                 }
 


### PR DESCRIPTION
This PR contains refactoring of OPM. 
Now you can use all timer channels to pulse generation on pins.

This is snapshot from running `examples/opm.rs` on stm32g071rb:
<img width="677" alt="stm32g0 opm" src="https://user-images.githubusercontent.com/1333916/135704213-1d6d5e5a-a59d-4f30-9ee2-37944c3c41db.png">
