### PR TITLE
OPM dynamic period change

### DIFF
--- a/examples/opm.rs
+++ b/examples/opm.rs
@@ -40,18 +40,19 @@ const APP: () = {
         let opm = ctx.device.TIM3.opm(4.ms(), &mut rcc);
 
         let mut opm_ch1 = opm.bind_pin(gpioa.pa6);
-        opm_ch1.enable();
-
         let mut opm_ch2 = opm.bind_pin(gpioa.pa7);
-        opm_ch2.set_delay(1.ms());
-        opm_ch2.enable();
-
         let mut opm_ch3 = opm.bind_pin(gpiob.pb0);
-        opm_ch3.set_delay(2.ms());
-        opm_ch3.enable();
-
         let mut opm_ch4 = opm.bind_pin(gpiob.pb1);
-        opm_ch4.set_delay(3.ms());
+
+        let max_delay = opm_ch2.get_max_delay();
+
+        opm_ch2.set_delay(max_delay / 2);
+        opm_ch3.set_delay(max_delay / 4);
+        opm_ch4.set_delay(max_delay / 8);
+
+        opm_ch1.enable();
+        opm_ch2.enable();
+        opm_ch3.enable();
         opm_ch4.enable();
 
         init::LateResources { opm, exti, led }


### PR DESCRIPTION
# What It Does

* Dynamic pulse width for timers in One-Pulse mode.