### PR TITLE
remove redundant type param in timer constructor

### DIFF
--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -108,7 +108,7 @@ macro_rules! timers {
 
             impl Timer<$TIM> {
                 /// Configures a TIM peripheral as a periodic count down timer
-                pub fn $tim<T>(tim: $TIM, rcc: &mut Rcc) -> Self {
+                pub fn $tim(tim: $TIM, rcc: &mut Rcc) -> Self {
                     $TIM::enable(rcc);
                     $TIM::reset(rcc);
 
@@ -166,7 +166,7 @@ macro_rules! timers {
 
             impl TimerExt<$TIM> for $TIM {
                 fn timer(self, rcc: &mut Rcc) -> Timer<$TIM> {
-                    Timer::$tim::<$TIM>(self, rcc)
+                    Timer::$tim(self, rcc)
                 }
             }
 


### PR DESCRIPTION
``` rust
// this is what I initially tried
let timer = Timer::tim1(dp.TIM1, &mut rcc); // cannot infer type for type parameter `T` declared on the associated function `tim1`

// this is my workaround
let timer = Timer::tim1::<()>(dp.TIM1, &mut rcc);

// this is what I later figured out is intented
let timer = dp.TIM1.timer(&mut rcc);
```

I'm actually surprised there's no lint for this similar to "unconstrained type parameter" on impls