### PR TITLE
Clear interrupt flag when starting a countdown timer

### DIFF
--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -181,6 +181,8 @@ macro_rules! timers {
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     // reset counter
                     self.tim.cnt.reset();
+                    // clear interrupt flag
+                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
 
                     // Calculate counter configuration
                     let cycles = timeout.into().cycles(self.clk);


### PR DESCRIPTION
Currently the interrupt flag gets reset only if you actively `wait` until the timer expires.
If you let the timer expire in the background and then `start` a new countdown it will immediatly expire again.