### PR TITLE
i2c: Take pins in DefaultMode rather than Output<OpenDrain>

### DIFF
--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -21,8 +21,8 @@ fn main() -> ! {
     let mut rcc = dp.RCC.constrain();
     let gpiob = dp.GPIOB.split(&mut rcc);
 
-    let sda = gpiob.pb7.into_open_drain_output();
-    let scl = gpiob.pb6.into_open_drain_output();
+    let sda = gpiob.pb7;
+    let scl = gpiob.pb6;
 
     let mut i2c = dp
         .I2C1

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -2,7 +2,7 @@
 use hal::blocking::i2c::{Read, Write, WriteRead};
 
 use crate::gpio::{gpioa::*, gpiob::*};
-use crate::gpio::{AltFunction, OpenDrain, Output};
+use crate::gpio::{AltFunction, DefaultMode};
 use crate::rcc::*;
 use crate::stm32::{I2C1, I2C2};
 use crate::time::Hertz;
@@ -174,7 +174,7 @@ macro_rules! i2c {
                 }
 
                 fn release(self) -> Self {
-                    self.into_open_drain_output()
+                    self.into_analog()
                 }
             }
         )+
@@ -186,7 +186,7 @@ macro_rules! i2c {
                 }
 
                 fn release(self) -> Self {
-                    self.into_open_drain_output()
+                    self.into_analog()
                 }
             }
         )+
@@ -415,14 +415,14 @@ i2c!(
     I2C1,
     i2c1,
     sda: [
-        PA10<Output<OpenDrain>>,
-        PB7<Output<OpenDrain>>,
-        PB9<Output<OpenDrain>>,
+        PA10<DefaultMode>,
+        PB7<DefaultMode>,
+        PB9<DefaultMode>,
     ],
     scl: [
-        PA9<Output<OpenDrain>>,
-        PB6<Output<OpenDrain>>,
-        PB8<Output<OpenDrain>>,
+        PA9<DefaultMode>,
+        PB6<DefaultMode>,
+        PB8<DefaultMode>,
     ],
 );
 
@@ -430,13 +430,13 @@ i2c!(
     I2C2,
     i2c2,
     sda: [
-        PA12<Output<OpenDrain>>,
-        PB11<Output<OpenDrain>>,
-        PB14<Output<OpenDrain>>,
+        PA12<DefaultMode>,
+        PB11<DefaultMode>,
+        PB14<DefaultMode>,
     ],
     scl: [
-        PA11<Output<OpenDrain>>,
-        PB10<Output<OpenDrain>>,
-        PB13<Output<OpenDrain>>,
+        PA11<DefaultMode>,
+        PB10<DefaultMode>,
+        PB13<DefaultMode>,
     ],
 );


### PR DESCRIPTION
Putting pins into open-drain mode causes them to be pulled low, which
can confuse other devices on the bus.

This is a breaking change. Calling code can be fixed by not calling
`into_open_drain_output()` on pins when setting up I2C.

Fixes #87