### PR TITLE
Fix stopwatch elapsed counter

### DIFF
--- a/src/timer/stopwatch.rs
+++ b/src/timer/stopwatch.rs
@@ -70,7 +70,7 @@ macro_rules! stopwatches {
 
                 pub fn elapsed(&self, ts: Instant) -> MicroSecond {
                     let now = self.now().0;
-                    let cycles = now.wrapping_sub(ts.0);
+                    let cycles = (now as u16).wrapping_sub(ts.0 as u16) as u32;
                     self.clk.duration(cycles * (1 + self.tim.psc.read().bits()))
                 }
 


### PR DESCRIPTION
All of the timers on the stm32g0x0 series MCUs are 16-bit counters. We store `now` and `ts.0` as 32-bit integers, which is fine except that then `wrapping_sub` will wrap as though they were 32-bit numbers.

Found this when writing a software-polled delay function using TIM16, the delay intervals would be uneven when it wraps. After making this change the elapsed count seems to be working correctly.