### PR TITLE
Do not reset all enabled clocks when enabling a single clock in RCC

### DIFF
--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -207,7 +207,7 @@ impl Rcc {
         assert!(pll_cfg.r > 1 && pll_cfg.r <= 8);
 
         // Disable PLL
-        self.cr.write(|w| w.pllon().clear_bit());
+        self.cr.modify(|_, w| w.pllon().clear_bit());
         while self.cr.read().pllrdy().bit_is_set() {}
 
         let (freq, pll_sw_bits) = match pll_cfg.mux {
@@ -261,30 +261,31 @@ impl Rcc {
         });
 
         // Enable PLL
-        self.cr.write(|w| w.pllon().set_bit());
+        self.cr.modify(|_, w| w.pllon().set_bit());
         while self.cr.read().pllrdy().bit_is_clear() {}
 
         PLLClocks { r, q, p }
     }
 
     pub(crate) fn enable_hsi(&self) {
-        self.cr.write(|w| w.hsion().set_bit());
+        self.cr.modify(|_, w| w.hsion().set_bit());
         while self.cr.read().hsirdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_hse(&self, bypass: bool) {
-        self.cr.write(|w| w.hseon().set_bit().hsebyp().bit(bypass));
+        self.cr
+            .modify(|_, w| w.hseon().set_bit().hsebyp().bit(bypass));
         while self.cr.read().hserdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_lse(&self, bypass: bool) {
         self.bdcr
-            .write(|w| w.lseon().set_bit().lsebyp().bit(bypass));
+            .modify(|_, w| w.lseon().set_bit().lsebyp().bit(bypass));
         while self.bdcr.read().lserdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_lsi(&self) {
-        self.csr.write(|w| w.lsion().set_bit());
+        self.csr.modify(|_, w| w.lsion().set_bit());
         while self.csr.read().lsirdy().bit_is_clear() {}
     }
 


### PR DESCRIPTION
During development the following did not work:

```rust
hal::rcc::Config::new(SysClockSrc::PLL).pll_cfg(PllConfig {
    mux: PLLSrc::HSE(16.mhz()),
    m: 1,
    n: 8,
    r: 2,
    q: None,
    p: None,
})
```

It would hang at:
```rust
while self.cr.read().pllrdy().bit_is_clear() {}
```

Due to HSE not being started (anymore), as `rcc::cr::hseon` would be reset to the reset value due to:
```rust
self.cr.write(|w| w.pllon().set_bit());
```
Which resets all bits in the `rcc::cr` register to the reset value. The default behaviour with PLL+HSI works because the HSI is immediately re-enabled when no other clock works.

This MR fixes this, allowing the user to select PLL+HSE for their clocks.