### PR TITLE
Updated stm32g0 crate to version 0.14.0 for cortex-m-rt 0.7.x support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ nb = "1.0.0"
 fugit = "0.3.5"
 
 [dependencies.stm32g0]
-version = "0.13.0"
+version = "0.14.0"
 features = ["rt"]
 
 [dependencies.bare-metal]
@@ -36,7 +36,7 @@ default-features = false
 version = "1.0.2"
 
 [dev-dependencies]
-cortex-m-rt = "0.6.10"
+cortex-m-rt = "0.7.1"
 cortex-m-rtic = "1.0.0"
 cortex-m-semihosting = "0.3.5"
 embedded-graphics = "0.5"


### PR DESCRIPTION
Updated stm32g0 crate to 0.14.0 for cortex-m-rt 0.7.x support. Personally, I need this for defmt-test support.

I would love to offer more testing for this as all I've done so far is run the blinky_delay on a STM32G031 target.