### PR TITLE
Allow querying of actual PWM frequency

### DIFF
--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -100,6 +100,9 @@ macro_rules! pwm {
             }
 
             impl Pwm<$TIMX> {
+                /// Set the PWM frequency. Actual frequency may differ from
+                /// requested due to precision of input clock. To check actual
+                /// frequency, call freq.
                 pub fn set_freq(&mut self, freq: Hertz) {
                     let ratio = self.clk / freq;
                     let psc = (ratio - 1) / 0xffff;
@@ -131,6 +134,13 @@ macro_rules! pwm {
                 /// Resets counter value
                 pub fn reset(&mut self) {
                     self.tim.cnt.reset();
+                }
+
+                /// Returns the currently configured frequency
+                pub fn freq(&self) -> Hertz {
+                    Hertz::from_raw(self.clk.raw()
+                        / (self.tim.psc.read().bits() + 1)
+                        / (self.tim.arr.read().bits() + 1))
                 }
             }
         )+


### PR DESCRIPTION
For PWM frequencies close to the clock source there can be quite a
difference between requested frequency and actual frequency. Providing a
way for the user to check what frequency they actually got can help with
debugging.