### PR TITLE
Make sure system isn't clocked from PLL before disabling it

### DIFF
--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -207,6 +207,16 @@ impl Rcc {
         assert!(pll_cfg.m > 0 && pll_cfg.m <= 8);
         assert!(pll_cfg.r > 1 && pll_cfg.r <= 8);
 
+        // If the system is currently clocked from the PLL, then switch back to
+        // the HSI before we disable the PLL, otherwise the PLL will refuse to
+        // switch off.
+        self.cfgr.modify(|r, w| {
+            if r.sw().bits() == 0b010 {
+                unsafe { w.sw().bits(0b000) };
+            }
+            w
+        });
+
         // Disable PLL
         self.cr.modify(|_, w| w.pllon().clear_bit());
         while self.cr.read().pllrdy().bit_is_set() {}


### PR DESCRIPTION
Without this change, the following code results in the second call to freeze never returning - it gets stuck in the while loop that waits for the PLL to turn off (`while self.cr.read().pllrdy().bit_is_set() {}`).

```rust
        let rcc = dp.RCC.constrain();
        let rcc = rcc.freeze(hal::rcc::Config::pll());
        let rcc = rcc.freeze(hal::rcc::Config::pll());
```