### PR TITLE
Fix compilation of examples with fault handlers

### DIFF
--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
@@ -46,7 +45,7 @@ fn main() -> ! {
 
 #[allow(clippy::empty_loop)]
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     hprintln!("Hard fault {:#?}", ef).unwrap();
     loop {}
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
@@ -47,11 +46,11 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("Hard fault {:#?}", ef);
 }
 
 #[exception]
-fn DefaultHandler(irqn: i16) {
+unsafe fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
@@ -38,6 +37,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("Hard fault {:#?}", ef);
 }


### PR DESCRIPTION
These handlers have been unsafe since cortex-m-rt version 0.7.0.