### PR TITLE
Allow open drain timer pin

### DIFF
--- a/src/timer/pins.rs
+++ b/src/timer/pins.rs
@@ -28,9 +28,9 @@ impl<TIM, PIN: TimerPin<TIM>> TriggerPin<TIM, PIN> {
 }
 
 macro_rules! timer_pins {
-    ($TIMX:ident, [ $(($ch:ty, $pin:ty, $af_mode:expr),)+ ]) => {
+    ($TIMX:ident, [ $(($ch:ty, $pin:tt, $af_mode:expr),)+ ]) => {
         $(
-            impl TimerPin<$TIMX> for $pin {
+            impl TimerPin<$TIMX> for $pin<Analog> {
                 type Channel = $ch;
 
                 fn setup(&self) {
@@ -41,6 +41,19 @@ macro_rules! timer_pins {
                     self.into_analog()
                 }
             }
+
+            impl TimerPin<$TIMX> for $pin<Output<OpenDrain>> {
+                type Channel = $ch;
+
+                fn setup(&self) {
+                    self.set_alt_mode($af_mode);
+                }
+
+                fn release(self) -> Self {
+                    self.into_open_drain_output()
+                }
+            }
+
         )+
     };
 }
@@ -114,106 +127,129 @@ trigger_pins!(TIM3, [
     (PC7<DefaultMode>, cc2p, ic2f),
 ]);
 
-timer_pins!(TIM1, [
-    (Channel1, PA8<DefaultMode>, AltFunction::AF2),
-    (Channel1, PC8<DefaultMode>, AltFunction::AF2),
-    (Channel2, PA9<DefaultMode>, AltFunction::AF2),
-    (Channel2, PB3<DefaultMode>, AltFunction::AF1),
-    (Channel2, PC9<DefaultMode>, AltFunction::AF2),
-    (Channel3, PA10<DefaultMode>, AltFunction::AF2),
-    (Channel3, PB6<DefaultMode>, AltFunction::AF1),
-    (Channel3, PC10<DefaultMode>, AltFunction::AF2),
-    (Channel4, PA11<DefaultMode>, AltFunction::AF2),
-    (Channel4, PC11<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM1,
+    [
+        (Channel1, PA8, AltFunction::AF2),
+        (Channel1, PC8, AltFunction::AF2),
+        (Channel2, PA9, AltFunction::AF2),
+        (Channel2, PB3, AltFunction::AF1),
+        (Channel2, PC9, AltFunction::AF2),
+        (Channel3, PA10, AltFunction::AF2),
+        (Channel3, PB6, AltFunction::AF1),
+        (Channel3, PC10, AltFunction::AF2),
+        (Channel4, PA11, AltFunction::AF2),
+        (Channel4, PC11, AltFunction::AF2),
+    ]
+);
 
 // Inverted pins
-timer_pins!(TIM1, [
-    (Channel1, PA7<DefaultMode>, AltFunction::AF2),
-    (Channel1, PB13<DefaultMode>, AltFunction::AF2),
-    (Channel1, PD2<DefaultMode>, AltFunction::AF2),
-    (Channel2, PB0<DefaultMode>, AltFunction::AF2),
-    (Channel2, PB14<DefaultMode>, AltFunction::AF2),
-    (Channel2, PD3<DefaultMode>, AltFunction::AF2),
-    (Channel3, PB1<DefaultMode>, AltFunction::AF2),
-    (Channel3, PB15<DefaultMode>, AltFunction::AF2),
-    (Channel3, PD4<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM1,
+    [
+        (Channel1, PA7, AltFunction::AF2),
+        (Channel1, PB13, AltFunction::AF2),
+        (Channel1, PD2, AltFunction::AF2),
+        (Channel2, PB0, AltFunction::AF2),
+        (Channel2, PB14, AltFunction::AF2),
+        (Channel2, PD3, AltFunction::AF2),
+        (Channel3, PB1, AltFunction::AF2),
+        (Channel3, PB15, AltFunction::AF2),
+        (Channel3, PD4, AltFunction::AF2),
+    ]
+);
 
 #[cfg(feature = "stm32g0x1")]
-timer_pins!(TIM2, [
-    (Channel1, PA0<DefaultMode>, AltFunction::AF2),
-    (Channel1, PA5<DefaultMode>, AltFunction::AF2),
-    (Channel1, PA15<DefaultMode>, AltFunction::AF2),
-    (Channel1, PC4<DefaultMode>, AltFunction::AF2),
-    (Channel2, PA1<DefaultMode>, AltFunction::AF2),
-    (Channel2, PB3<DefaultMode>, AltFunction::AF2),
-    (Channel2, PC5<DefaultMode>, AltFunction::AF2),
-    (Channel3, PA2<DefaultMode>, AltFunction::AF2),
-    (Channel3, PB10<DefaultMode>, AltFunction::AF2),
-    (Channel3, PC6<DefaultMode>, AltFunction::AF2),
-    (Channel4, PA3<DefaultMode>, AltFunction::AF2),
-    (Channel4, PB11<DefaultMode>, AltFunction::AF2),
-    (Channel4, PC7<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM2,
+    [
+        (Channel1, PA0, AltFunction::AF2),
+        (Channel1, PA5, AltFunction::AF2),
+        (Channel1, PA15, AltFunction::AF2),
+        (Channel1, PC4, AltFunction::AF2),
+        (Channel2, PA1, AltFunction::AF2),
+        (Channel2, PB3, AltFunction::AF2),
+        (Channel2, PC5, AltFunction::AF2),
+        (Channel3, PA2, AltFunction::AF2),
+        (Channel3, PB10, AltFunction::AF2),
+        (Channel3, PC6, AltFunction::AF2),
+        (Channel4, PA3, AltFunction::AF2),
+        (Channel4, PB11, AltFunction::AF2),
+        (Channel4, PC7, AltFunction::AF2),
+    ]
+);
 
-timer_pins!(TIM3, [
-    (Channel1, PA6<DefaultMode>, AltFunction::AF1),
-    (Channel1, PB4<DefaultMode>, AltFunction::AF1),
-    (Channel1, PC6<DefaultMode>, AltFunction::AF1),
-    (Channel2, PA7<DefaultMode>, AltFunction::AF1),
-    (Channel2, PB5<DefaultMode>, AltFunction::AF1),
-    (Channel2, PC7<DefaultMode>, AltFunction::AF1),
-    (Channel3, PB0<DefaultMode>, AltFunction::AF1),
-    (Channel3, PC8<DefaultMode>, AltFunction::AF1),
-    (Channel4, PB1<DefaultMode>, AltFunction::AF1),
-    (Channel4, PC9<DefaultMode>, AltFunction::AF1),
-]);
+timer_pins!(
+    TIM3,
+    [
+        (Channel1, PA6, AltFunction::AF1),
+        (Channel1, PB4, AltFunction::AF1),
+        (Channel1, PC6, AltFunction::AF1),
+        (Channel2, PA7, AltFunction::AF1),
+        (Channel2, PB5, AltFunction::AF1),
+        (Channel2, PC7, AltFunction::AF1),
+        (Channel3, PB0, AltFunction::AF1),
+        (Channel3, PC8, AltFunction::AF1),
+        (Channel4, PB1, AltFunction::AF1),
+        (Channel4, PC9, AltFunction::AF1),
+    ]
+);
 
-timer_pins!(TIM14, [
-    (Channel1, PA4<DefaultMode>, AltFunction::AF4),
-    (Channel1, PA7<DefaultMode>, AltFunction::AF4),
-    (Channel1, PB1<DefaultMode>, AltFunction::AF0),
-    (Channel1, PC12<DefaultMode>, AltFunction::AF2),
-    (Channel1, PF0<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM14,
+    [
+        (Channel1, PA4, AltFunction::AF4),
+        (Channel1, PA7, AltFunction::AF4),
+        (Channel1, PB1, AltFunction::AF0),
+        (Channel1, PC12, AltFunction::AF2),
+        (Channel1, PF0, AltFunction::AF2),
+    ]
+);
 
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
-timer_pins!(TIM15, [
-    (Channel1, PA2<DefaultMode>, AltFunction::AF5),
-    (Channel1, PB14<DefaultMode>, AltFunction::AF5),
-    (Channel1, PC1<DefaultMode>, AltFunction::AF2),
-    (Channel2, PA3<DefaultMode>, AltFunction::AF5),
-    (Channel2, PB15<DefaultMode>, AltFunction::AF5),
-    (Channel2, PC2<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM15,
+    [
+        (Channel1, PA2, AltFunction::AF5),
+        (Channel1, PB14, AltFunction::AF5),
+        (Channel1, PC1, AltFunction::AF2),
+        (Channel2, PA3, AltFunction::AF5),
+        (Channel2, PB15, AltFunction::AF5),
+        (Channel2, PC2, AltFunction::AF2),
+    ]
+);
 
 // Inverted pins
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
-timer_pins!(TIM15, [
-    (Channel1, PA1<DefaultMode>, AltFunction::AF5),
-    (Channel1, PB13<DefaultMode>, AltFunction::AF5),
-    (Channel1, PF1<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM15,
+    [
+        (Channel1, PA1, AltFunction::AF5),
+        (Channel1, PB13, AltFunction::AF5),
+        (Channel1, PF1, AltFunction::AF2),
+    ]
+);
 
-timer_pins!(TIM16, [
-    (Channel1, PA6<DefaultMode>, AltFunction::AF5),
-    (Channel1, PB8<DefaultMode>, AltFunction::AF2),
-    (Channel1, PD0<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM16,
+    [
+        (Channel1, PA6, AltFunction::AF5),
+        (Channel1, PB8, AltFunction::AF2),
+        (Channel1, PD0, AltFunction::AF2),
+    ]
+);
 
 // Inverted pins
-timer_pins!(TIM16, [
-    (Channel1, PB6<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(TIM16, [(Channel1, PB6, AltFunction::AF2),]);
 
-timer_pins!(TIM17, [
-    (Channel1, PA7<DefaultMode>, AltFunction::AF6),
-    (Channel1, PB9<DefaultMode>, AltFunction::AF2),
-    (Channel1, PD1<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(
+    TIM17,
+    [
+        (Channel1, PA7, AltFunction::AF6),
+        (Channel1, PB9, AltFunction::AF2),
+        (Channel1, PD1, AltFunction::AF2),
+    ]
+);
 
 //  Inverted pins
-timer_pins!(TIM17, [
-    (Channel1, PB7<DefaultMode>, AltFunction::AF2),
-]);
+timer_pins!(TIM17, [(Channel1, PB7, AltFunction::AF2),]);


### PR DESCRIPTION
I2C SDA and SCL pins use similar approach - they accept `Output<OpenDrain>` and then set alternate function mode.
- remove generic MODE parameter from macro invocations
- generate TimerPin trait impl for `Analog` and `Output<OpenDrain>` modes