### PR TITLE
Fix i2c data lost on start repeat condition

### DIFF
--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -24,13 +24,23 @@ pub enum SlaveAddressMask {
     MaskAllBits,
 }
 
+/// Denotes which event marked the end of the I2C data
 #[derive(Debug, Clone, Copy)]
-pub enum I2cResult<'a> {
-    Data(u16, I2cDirection, &'a [u8]), // contains address, direction and data slice reference
-    Addressed(u16, I2cDirection),      // a slave is addressed by a master
+pub enum EndMarker {
+    /// A stop condition was encountered
+    Stop,
+    /// A start repeat condition was encountered
+    StartRepeat,
 }
 
 #[derive(Debug, Clone, Copy)]
+pub enum I2cResult<'a> {
+    /// Contains address, direction, data slice reference, and the packet delimeter
+    Data(u16, I2cDirection, &'a [u8], EndMarker),
+    Addressed(u16, I2cDirection), // a slave is addressed by a master
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum I2cDirection {
     MasterReadSlaveWrite = 0,
     MasterWriteSlaveRead = 1,
@@ -99,4 +109,5 @@ pub struct I2c<I2C, SDA, SCL> {
     length_write_read: usize, // for a master write_read operation this remembers the size of the read operation
     // for a slave device this must be 0
     data: [u8; 255], // during transfer the driver will be the owner of the buffer
+    current_direction: I2cDirection,
 }


### PR DESCRIPTION
`I2cResult::Data` is only given by I2c::check_isr_flags when the stop condition interrupt is generated. The problem being that the stop condition interrupt is not generated on a repeated start condition.

This fixes the issue by checking if there is pending data when an address interrupt is pending. This means that there wasn't a stop condition after the last address event.

`I2cResult::Data` also now returns the type of event which marked the end of the data. This is useful if special functionality is desired depending on the type of event. For example, some I2C interfaces require that the register and read/write commands be issued with no stop conditions between them.

Fixes #136 