### PR TITLE
Fix `is_pending` Logical Error

### DIFF
--- a/src/exti.rs
+++ b/src/exti.rs
@@ -169,7 +169,7 @@ impl ExtiExt for EXTI {
             SignalEdge::Rising => self.rpr1.read().bits() & mask != 0,
             SignalEdge::Falling => self.fpr1.read().bits() & mask != 0,
             SignalEdge::All => {
-                (self.rpr1.read().bits() & mask != 0) && (self.fpr1.read().bits() & mask != 0)
+                (self.rpr1.read().bits() & mask != 0) || (self.fpr1.read().bits() & mask != 0)
             }
         }
     }


### PR DESCRIPTION
When checking for the edge event, `SignalEdge::All` required the event to be both rising *and* falling, when in reality it should be either rising *or* falling.

A simple fix from `&&` to `||`.

Tested with RTIC on STM32g031K8.