### PR TITLE
Update stm32g0 to 0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ nb = "1.0.0"
 fugit = "0.3.5"
 
 [dependencies.stm32g0]
-version = "0.14.0"
+version = "0.15.1"
 features = ["rt"]
 
 [dependencies.bare-metal]

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -362,7 +362,7 @@ where
             .modify(|_, w| unsafe { w.smp1().bits(self.sample_time as u8) });
 
         self.rb
-            .chselr() // set activ channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
+            .chselr0() // set active channel acording chapter 15.12.9 (ADC_CFGR1; CHSELRMOD=0)
             .modify(|_, w| unsafe { w.chsel().bits(1 << PIN::channel()) });
     }
 }
@@ -415,7 +415,7 @@ where
             .modify(|_, w| unsafe { w.smp1().bits(self.sample_time as u8) });
 
         self.rb
-            .chselr()
+            .chselr0()
             .modify(|_, w| unsafe { w.chsel().bits(1 << PIN::channel()) });
 
         self.rb.isr.modify(|_, w| w.eos().set_bit());

--- a/src/analog/dac.rs
+++ b/src/analog/dac.rs
@@ -106,8 +106,8 @@ macro_rules! dac {
                 pub fn enable(self) -> $CX<Enabled> {
                     let dac = unsafe { &(*DAC::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(1) });
-                    dac.dac_cr.modify(|_, w| w.$en().set_bit());
+                    dac.mcr.modify(|_, w| unsafe { w.$mode().bits(1) });
+                    dac.cr.modify(|_, w| w.$en().set_bit());
 
                     $CX {
                         _enabled: PhantomData,
@@ -117,8 +117,8 @@ macro_rules! dac {
                 pub fn enable_unbuffered(self) -> $CX<EnabledUnbuffered> {
                     let dac = unsafe { &(*DAC::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(2) });
-                    dac.dac_cr.modify(|_, w| w.$en().set_bit());
+                    dac.mcr.modify(|_, w| unsafe { w.$mode().bits(2) });
+                    dac.cr.modify(|_, w| w.$en().set_bit());
 
                     $CX {
                         _enabled: PhantomData,
@@ -128,8 +128,8 @@ macro_rules! dac {
                 pub fn enable_generator(self, config: GeneratorConfig) -> $CX<WaveGenerator> {
                     let dac = unsafe { &(*DAC::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(1) });
-                    dac.dac_cr.modify(|_, w| unsafe {
+                    dac.mcr.modify(|_, w| unsafe { w.$mode().bits(1) });
+                    dac.cr.modify(|_, w| unsafe {
                         w.$wave().bits(config.mode);
                         w.$ten().set_bit();
                         w.$mamp().bits(config.amp);
@@ -159,19 +159,19 @@ macro_rules! dac {
                     T: DelayUs<u32>,
                 {
                     let dac = unsafe { &(*DAC::ptr()) };
-                    dac.dac_cr.modify(|_, w| w.$en().clear_bit());
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(0) });
-                    dac.dac_cr.modify(|_, w| w.$cen().set_bit());
+                    dac.cr.modify(|_, w| w.$en().clear_bit());
+                    dac.mcr.modify(|_, w| unsafe { w.$mode().bits(0) });
+                    dac.cr.modify(|_, w| w.$cen().set_bit());
                     let mut trim = 0;
                     while true {
-                        dac.dac_ccr.modify(|_, w| unsafe { w.$trim().bits(trim) });
+                        dac.ccr.modify(|_, w| unsafe { w.$trim().bits(trim) });
                         delay.delay_us(64_u32);
-                        if dac.dac_sr.read().$cal_flag().bit() {
+                        if dac.sr.read().$cal_flag().bit() {
                             break;
                         }
                         trim += 1;
                     }
-                    dac.dac_cr.modify(|_, w| w.$cen().clear_bit());
+                    dac.cr.modify(|_, w| w.$cen().clear_bit());
 
                     $CX {
                         _enabled: PhantomData,
@@ -181,7 +181,7 @@ macro_rules! dac {
                 /// Disable the DAC channel
                 pub fn disable(self) -> $CX<Disabled> {
                     let dac = unsafe { &(*DAC::ptr()) };
-                    dac.dac_cr.modify(|_, w| unsafe {
+                    dac.cr.modify(|_, w| unsafe {
                         w.$en().clear_bit().$wave().bits(0).$ten().clear_bit()
                     });
 
@@ -209,7 +209,7 @@ macro_rules! dac {
             impl $CX<WaveGenerator> {
                 pub fn trigger(&mut self) {
                     let dac = unsafe { &(*DAC::ptr()) };
-                    dac.dac_swtrgr.write(|w| { w.$swtrig().set_bit() });
+                    dac.swtrgr.write(|w| { w.$swtrig().set_bit() });
                 }
             }
         )+
@@ -239,8 +239,8 @@ dac!(
             cal_flag1,
             otrim1,
             mode1,
-            dac_dhr12r1,
-            dac_dor1,
+            dhr12r1,
+            dor1,
             dacc1dhr,
             wave1,
             mamp1,
@@ -254,8 +254,8 @@ dac!(
             cal_flag2,
             otrim2,
             mode2,
-            dac_dhr12r2,
-            dac_dor2,
+            dhr12r2,
+            dor2,
             dacc2dhr,
             wave2,
             mamp2,

--- a/src/dmamux.rs
+++ b/src/dmamux.rs
@@ -185,13 +185,13 @@ macro_rules! dma_mux {
 #[cfg(any(feature = "stm32g070", feature = "stm32g071", feature = "stm32g081"))]
 dma_mux!(
     channels: {
-        C0: (ch0, dmamux_c0cr),
-        C1: (ch1, dmamux_c1cr),
-        C2: (ch2, dmamux_c2cr),
-        C3: (ch3, dmamux_c3cr),
-        C4: (ch4, dmamux_c4cr),
-        C5: (ch5, dmamux_c5cr),
-        C6: (ch6, dmamux_c6cr),
+        C0: (ch0, c0cr),
+        C1: (ch1, c1cr),
+        C2: (ch2, c2cr),
+        C3: (ch3, c3cr),
+        C4: (ch4, c4cr),
+        C5: (ch5, c5cr),
+        C6: (ch6, c6cr),
     },
 );
 

--- a/src/i2c/blocking.rs
+++ b/src/i2c/blocking.rs
@@ -187,7 +187,7 @@ macro_rules! i2c {
 
                 if config.slave_address_1 > 0 {
                     i2c.oar1.write(|w| unsafe {
-                        w.oa1_7_1().bits(config.slave_address_1 as u8)
+                        w.oa1().bits(config.slave_address_1)
                         .oa1mode().bit(config.address_11bits)
                         .oa1en().set_bit()
                     });

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -169,7 +169,7 @@ macro_rules! spi {
                 // Enable pins
                 pins.setup();
 
-                spi.cr1.write(|w| unsafe {
+                spi.cr1.write(|w| {
                     w.cpha()
                         .bit(mode.phase == Phase::CaptureOnSecondTransition)
                         .cpol()
@@ -186,12 +186,10 @@ macro_rules! spi {
                         .set_bit()
                         .rxonly()
                         .clear_bit()
-                        .dff()
+                        .crcl()
                         .clear_bit()
                         .bidimode()
                         .clear_bit()
-                        .ssi()
-                        .set_bit()
                         .spe()
                         .set_bit()
                 });

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -83,7 +83,7 @@ pub struct WindowWatchdog {
 
 impl WindowWatchdog {
     pub fn feed(&mut self) {
-        self.wwdg.cr.write(|w| unsafe { w.t().bits(0xff) });
+        self.wwdg.cr.write(|w| w.t().bits(0xff));
     }
 
     pub fn set_window(&mut self, window: MicroSecond) {
@@ -101,7 +101,7 @@ impl WindowWatchdog {
         assert!(window <= 0x40);
         self.wwdg
             .cfr
-            .write(|w| unsafe { w.wdgtb().bits(psc).w().bits(window as u8) });
+            .write(|w| w.wdgtb().bits(psc).w().bits(window as u8));
     }
 
     pub fn listen(&mut self) {


### PR DESCRIPTION
I see there have already been two attempts to update this dependency, blocked by the malformed SVD for the new MCUs. This CL doesn't try to add any new MCUs directly; it just updates a dependency.

I plan to add G0B1 MCU later, which is unaffected by the SVD problem.