### PR TITLE
Add implementation of new Instance type so that I2c works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,12 @@ default-features = false
 version = "1.0.2"
 
 [dev-dependencies]
+stm32g0xx-hal = { path = ".", features = ["defmt", "rt"] }
+
 cortex-m-rt = "0.7.5"
 cortex-m-semihosting = "0.5.0"
-defmt-rtt = "0.4.0"
+defmt = "0.3"
+defmt-rtt = "0.4"
 panic-halt = "1.0.0"
 panic-semihosting = "0.6.0"
 rtic = { version = "2.1.1", features = ["thumbv6-backend"] }

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -3,17 +3,15 @@
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-extern crate cortex_m_rt as rt;
-extern crate cortex_m_semihosting as sh;
-extern crate panic_halt;
-extern crate stm32g0xx_hal as hal;
+use cortex_m_semihosting as _;
+use defmt_rtt as _;
+use panic_halt as _;
+use stm32g0xx_hal as hal;
 
+use cortex_m_rt::entry;
 use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
-use rt::entry;
-use sh::hprintln;
 
 #[entry]
 fn main() -> ! {
@@ -31,8 +29,8 @@ fn main() -> ! {
     let buf: [u8; 1] = [0];
     loop {
         match i2c.write(0x3c, &buf) {
-            Ok(_) => hprintln!("ok"),
-            Err(err) => hprintln!("error: {:?}", err),
+            Ok(_) => defmt::println!("ok"),
+            Err(err) => defmt::println!("error: {:?}", err),
         }
     }
 }

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -89,6 +89,9 @@ pub trait Instance:
 {
 }
 
+impl Instance for crate::stm32::I2C1 {}
+impl Instance for crate::stm32::I2C2 {}
+
 /// I2C SDA pin
 pub trait SDAPin<I2C> {
     fn setup(&self);


### PR DESCRIPTION
The new Instance trait for I2C needs to be implemented *somewhere*.
I don't know if this is a good place or not, but this gets the I2C example back to working.

Tested in hardware on Nucleo G071RB